### PR TITLE
Fix bad match in map_arity

### DIFF
--- a/src/showtime_ffi.erl
+++ b/src/showtime_ffi.erl
@@ -164,11 +164,11 @@ map_extra_info_list(ExtraInfoList) ->
     ).
 
 map_arity(Arity) ->
-    case Arity of
-        [head | tail] ->
-            {arg_list, [head | tail]};
-        Num ->
-            {num, Num}
+    if 
+        is_list(Arity) ->
+            {arg_list, Arity};
+        is_integer(Arity) ->
+            {num, Arity}
     end.
 
 functions() ->


### PR DESCRIPTION
It currently matches an improper list with the atom `head` as the head and the atom `tail` as the tail. Erlang variables (bindings) start with uppercase, so this looks like a typo.

Instead of a `case` with such a match we can use `if` and check the type of `Arity`, which is excatly what this commit does.