### PR TITLE
Upgrade gleam 0 30

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1.15.0
         with:
           otp-version: "25.2"
-          gleam-version: "0.28.3"
+          gleam-version: "0.30.1"
           rebar3-version: "3"
           # elixir-version: "1.14.2"
       - run: gleam format --check src test

--- a/gleam.toml
+++ b/gleam.toml
@@ -16,7 +16,7 @@ gleam_erlang = "~> 0.18"
 gleam_otp = "~> 0.5"
 gleam_community_ansi = "~> 1.1"
 glint = "~> 0.12-rc5"
-gap = "~> 0.4"
+gap = "~> 0.7"
 snag = "~> 0.2"
 
 [dev-dependencies]

--- a/gleam.toml
+++ b/gleam.toml
@@ -15,7 +15,7 @@ gleam_stdlib = "~> 0.28"
 gleam_erlang = "~> 0.18"
 gleam_otp = "~> 0.5"
 gleam_community_ansi = "~> 1.1"
-glint = "~> 0.11"
+glint = "~> 0.12-rc5"
 gap = "~> 0.4"
 snag = "~> 0.2"
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,4 +1,5 @@
 name = "showtime"
+gleam = ">= 0.30.0"
 version = "0.1.6"
 
 # Fill out these fields if you intend to generate HTML documentation or publish
@@ -11,8 +12,8 @@ repository = { type = "github", user = "JohnBjrk", repo = "showtime" }
 target = "erlang"
 
 [dependencies]
-gleam_stdlib = "~> 0.28"
-gleam_erlang = "~> 0.18"
+gleam_stdlib = "~> 0.29"
+gleam_erlang = "~> 0.19"
 gleam_otp = "~> 0.5"
 gleam_community_ansi = "~> 1.1"
 glint = "~> 0.12-rc5"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,24 +2,24 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gap", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_stdlib"], otp_app = "gap", source = "hex", outer_checksum = "E5E41C183C6A1AC32039BF29500E855F0E5FC26A3455DA745D6CD28C9970726F" },
+  { name = "gap", version = "0.5.0", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_stdlib"], otp_app = "gap", source = "hex", outer_checksum = "97652371A8313F9313BF84049C87CF1B9DE29C185D012F3AE963D9EBF8268EA2" },
   { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
-  { name = "gleam_community_ansi", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib", "gleam_bitwise"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "6E4E0CF2B207C1A7FCD3C21AA43514D67BC7004F21F82045CDCCE6C727A14862" },
+  { name = "gleam_community_ansi", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "6E4E0CF2B207C1A7FCD3C21AA43514D67BC7004F21F82045CDCCE6C727A14862" },
   { name = "gleam_community_colour", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "D27CE357ECB343929A8CEC3FBA0B499943A47F0EE1F589EE16AFC2DC21C61E5B" },
   { name = "gleam_erlang", version = "0.19.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "720D1E0A0CEBBD51C4AA88501D1D4FBFEF4AA7B3332C994691ED944767A52582" },
   { name = "gleam_otp", version = "0.5.3", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "6E705B69464237353E0380AC8143BDB29A3F0BF6168755D5F2D6E55A34A8B077" },
-  { name = "gleam_stdlib", version = "0.29.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "24581B17879AA903B3E7531869D9460730C2F772A1C02C774ABF75710CCC4CFE" },
+  { name = "gleam_stdlib", version = "0.29.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B296BF9B8AA384A6B64CD49F333016A9DCA6AC73A95400D17F2271E072EFF986" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
-  { name = "glint", version = "0.11.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_community_colour", "gleam_community_ansi", "snag"], otp_app = "glint", source = "hex", outer_checksum = "B3B95A640C86B5833033B4B74276C7B1D2AA04634D845B526C56A8BC52F5D15F" },
-  { name = "snag", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "35C63E478782C58236F1050297C2FDF9806A4DD55C6FAF0B6EC5E54BC119342D" },
+  { name = "glint", version = "0.12.0-rc5", build_tools = ["gleam"], requirements = ["snag", "gleam_stdlib", "gleam_community_ansi", "gleam_community_colour"], otp_app = "glint", source = "hex", outer_checksum = "2466CADA6519A989CA1389288685574F553D2EC2EF7A020E5A3ACAAA4E41382B" },
+  { name = "snag", version = "0.2.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "8FD70D8FB3728E08AC425283BB509BB0F012BE1AE218424A597CDE001B0EE589" },
 ]
 
 [requirements]
-gap = "~> 0.4"
-gleam_community_ansi = "~> 1.1"
-gleam_erlang = "~> 0.18"
-gleam_otp = "~> 0.5"
-gleam_stdlib = "~> 0.28"
-gleeunit = "~> 0.10"
-glint = "~> 0.11"
-snag = "~> 0.2"
+gap = { version = "~> 0.4" }
+gleam_community_ansi = { version = "~> 1.1" }
+gleam_erlang = { version = "~> 0.18" }
+gleam_otp = { version = "~> 0.5" }
+gleam_stdlib = { version = "~> 0.28" }
+gleeunit = { version = "~> 0.10" }
+glint = { version = "~> 0.12-rc5" }
+snag = { version = "~> 0.2" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,24 +2,24 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gap", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_stdlib"], otp_app = "gap", source = "hex", outer_checksum = "AF290C27B3FAE5FE64E1B7E9C70A9E29AA0F42429C0592D375770C1C51B79D36" },
+  { name = "gap", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_community_ansi"], otp_app = "gap", source = "hex", outer_checksum = "AF290C27B3FAE5FE64E1B7E9C70A9E29AA0F42429C0592D375770C1C51B79D36" },
   { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
-  { name = "gleam_community_ansi", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_bitwise", "gleam_community_colour"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "6E4E0CF2B207C1A7FCD3C21AA43514D67BC7004F21F82045CDCCE6C727A14862" },
-  { name = "gleam_community_colour", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "D27CE357ECB343929A8CEC3FBA0B499943A47F0EE1F589EE16AFC2DC21C61E5B" },
+  { name = "gleam_community_ansi", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_bitwise", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "6E4E0CF2B207C1A7FCD3C21AA43514D67BC7004F21F82045CDCCE6C727A14862" },
+  { name = "gleam_community_colour", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_bitwise"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "D27CE357ECB343929A8CEC3FBA0B499943A47F0EE1F589EE16AFC2DC21C61E5B" },
   { name = "gleam_erlang", version = "0.19.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "720D1E0A0CEBBD51C4AA88501D1D4FBFEF4AA7B3332C994691ED944767A52582" },
   { name = "gleam_otp", version = "0.5.3", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_erlang"], otp_app = "gleam_otp", source = "hex", outer_checksum = "6E705B69464237353E0380AC8143BDB29A3F0BF6168755D5F2D6E55A34A8B077" },
   { name = "gleam_stdlib", version = "0.29.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B296BF9B8AA384A6B64CD49F333016A9DCA6AC73A95400D17F2271E072EFF986" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
-  { name = "glint", version = "0.12.0-rc5", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_community_ansi", "snag", "gleam_community_colour"], otp_app = "glint", source = "hex", outer_checksum = "2466CADA6519A989CA1389288685574F553D2EC2EF7A020E5A3ACAAA4E41382B" },
+  { name = "glint", version = "0.12.0-rc5", build_tools = ["gleam"], requirements = ["snag", "gleam_community_ansi", "gleam_stdlib", "gleam_community_colour"], otp_app = "glint", source = "hex", outer_checksum = "2466CADA6519A989CA1389288685574F553D2EC2EF7A020E5A3ACAAA4E41382B" },
   { name = "snag", version = "0.2.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "8FD70D8FB3728E08AC425283BB509BB0F012BE1AE218424A597CDE001B0EE589" },
 ]
 
 [requirements]
 gap = { version = "~> 0.7" }
 gleam_community_ansi = { version = "~> 1.1" }
-gleam_erlang = { version = "~> 0.18" }
+gleam_erlang = { version = "~> 0.19" }
 gleam_otp = { version = "~> 0.5" }
-gleam_stdlib = { version = "~> 0.28" }
+gleam_stdlib = { version = "~> 0.29" }
 gleeunit = { version = "~> 0.10" }
 glint = { version = "~> 0.12-rc5" }
 snag = { version = "~> 0.2" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,20 +2,20 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gap", version = "0.5.0", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_stdlib"], otp_app = "gap", source = "hex", outer_checksum = "97652371A8313F9313BF84049C87CF1B9DE29C185D012F3AE963D9EBF8268EA2" },
+  { name = "gap", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_stdlib"], otp_app = "gap", source = "hex", outer_checksum = "AF290C27B3FAE5FE64E1B7E9C70A9E29AA0F42429C0592D375770C1C51B79D36" },
   { name = "gleam_bitwise", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "6064699EFBABB1CA392DCB193D0E8B402FB042B4B46857B01E6875E643B57F54" },
-  { name = "gleam_community_ansi", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "6E4E0CF2B207C1A7FCD3C21AA43514D67BC7004F21F82045CDCCE6C727A14862" },
+  { name = "gleam_community_ansi", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_bitwise", "gleam_community_colour"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "6E4E0CF2B207C1A7FCD3C21AA43514D67BC7004F21F82045CDCCE6C727A14862" },
   { name = "gleam_community_colour", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "D27CE357ECB343929A8CEC3FBA0B499943A47F0EE1F589EE16AFC2DC21C61E5B" },
   { name = "gleam_erlang", version = "0.19.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "720D1E0A0CEBBD51C4AA88501D1D4FBFEF4AA7B3332C994691ED944767A52582" },
-  { name = "gleam_otp", version = "0.5.3", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "6E705B69464237353E0380AC8143BDB29A3F0BF6168755D5F2D6E55A34A8B077" },
+  { name = "gleam_otp", version = "0.5.3", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_erlang"], otp_app = "gleam_otp", source = "hex", outer_checksum = "6E705B69464237353E0380AC8143BDB29A3F0BF6168755D5F2D6E55A34A8B077" },
   { name = "gleam_stdlib", version = "0.29.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B296BF9B8AA384A6B64CD49F333016A9DCA6AC73A95400D17F2271E072EFF986" },
   { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
-  { name = "glint", version = "0.12.0-rc5", build_tools = ["gleam"], requirements = ["snag", "gleam_stdlib", "gleam_community_ansi", "gleam_community_colour"], otp_app = "glint", source = "hex", outer_checksum = "2466CADA6519A989CA1389288685574F553D2EC2EF7A020E5A3ACAAA4E41382B" },
+  { name = "glint", version = "0.12.0-rc5", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_community_ansi", "snag", "gleam_community_colour"], otp_app = "glint", source = "hex", outer_checksum = "2466CADA6519A989CA1389288685574F553D2EC2EF7A020E5A3ACAAA4E41382B" },
   { name = "snag", version = "0.2.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "8FD70D8FB3728E08AC425283BB509BB0F012BE1AE218424A597CDE001B0EE589" },
 ]
 
 [requirements]
-gap = { version = "~> 0.4" }
+gap = { version = "~> 0.7" }
 gleam_community_ansi = { version = "~> 1.1" }
 gleam_erlang = { version = "~> 0.18" }
 gleam_otp = { version = "~> 0.5" }

--- a/snapshots/js_capture_mixed.txt
+++ b/snapshots/js_capture_mixed.txt
@@ -14,129 +14,6 @@ has som lines of output
 Which is also followed by an io.debug()
 TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "list"])
 
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36massert_test:213[39m[22m                 
-     [36mExpected[39m: Patterns should match                         
-          [36mGot[39m: [1m[31mError("bepa")[39m[22m                                 
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.assert_test                     
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ----------------------⌄                       
-         [36mTest[39m: showtime_test.[1m[36mdiff_custom_test[39m[22m                
-  [36mDescription[39m: Testing diffs of custom types                 
-     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m]
-          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.equal                                    
-               should.equal_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mdiff_long_test[39m[22m                  
-  [36mDescription[39m: Testing long expected and got                 
-     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m]
-          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.equal                                    
-               should.equal_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ----------------------⌄                       
-         [36mTest[39m: showtime_test.[1m[36mdiff_string_test[39m[22m                
-  [36mDescription[39m: Test diffing of strings                       
-     [36mExpected[39m: [1m[32mt[39m[22m[1m[32mh[39m[22m[1m[32me[39m[22m test t[1m[32mh[39m[22ming                                
-          [36mGot[39m: [1m[31ma[39m[22m test [1m[31ms[39m[22mt[1m[31mr[39m[22ming                                 
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.equal                                    
-               should.equal_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mdjur_test[39m[22m                       
-     [36mExpected[39m: [1mnot [22mTestType(arg1: "apa", arg2: ["ren", "tur"])
-          [36mGot[39m: TestType(arg1: "apa", arg2: ["ren", "tur"])   
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.djur_test                       
-               should.not_equal                              
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mfail_meta_test[39m[22m                  
-  [36mDescription[39m: Test fail with meta-data                      
-     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
-          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.fail                                     
-               should.fail_meta                              
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mfail_test[39m[22m                       
-     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
-          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.fail_test                       
-               should.fail                                   
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: -------------------------⌄                    
-         [36mTest[39m: showtime_test.[1m[36mgeneric_exception_test[39m[22m          
-     [36mExpected[39m: Exception in test function                    
-          [36mGot[39m: [1m[31mTestType(arg1: "Generic", arg2: [])[39m[22m           
-                                                           
-       [1m[31mFailed[39m[22m: -----------------------------⌄                
-         [36mTest[39m: showtime_test.[1m[36mgleeunit_assert_not_equal_test[39m[22m  
-     [36mExpected[39m: [1mnot [22m"1"                                       
-          [36mGot[39m: "1"                                           
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.gleeunit_assert_not_equal_test  
-               should.not_equal                              
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: ----------------------------⌄                 
-         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_error_test[39m[22m   
-     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
-          [36mGot[39m: [1m[31mOk("TestType(arg1: \"Done\", arg2: [\"good\", \"result\"])")[39m[22m
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.gleeunit_should_be_error_test   
-               should.be_error                               
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: ---------------------------⌄                  
-         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_ok_test[39m[22m      
-     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
-          [36mGot[39m: [1m[31mError("\"Wrong\"")[39m[22m                            
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.gleeunit_should_be_ok_test      
-               should.be_ok                                  
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mi_am_test[39m[22m                       
-     [36mExpected[39m: [1m[32mT[39m[22m[1m[32me[39m[22m[1m[32ms[39m[22m[1m[32mt[39m[22m[1m[32mT[39m[22m[1m[32my[39m[22m[1m[32mp[39m[22m[1m[32me[39m[22m[1m[32m([39m[22mar[1m[32mg[39m[22m[1m[32m1[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22m[1m[32mn[39m[22m[1m[32ma[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22ma[1m[32mr[39m[22m[1m[32mg[39m[22m[1m[32m2[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m[[39m[22m[1m[32m"[39m[22m[1m[32ms[39m[22m[1m[32mo[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22mn[1m[32ma[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m][39m[22m[1m[32m)[39m[22m
-          [36mGot[39m: [1m[31mV[39m[22mar[1m[31mi[39m[22man[1m[31mt[39m[22m                                       
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.i_am_test                       
-               should.equal                                  
-               gleeunit_ffi.crash                            
-       [36mOutput[39m: Some test output                              
-               And the some really really really really really really really really really really really really really really really really really really really really long output
-                                                           
        [1m[31mFailed[39m[22m: -----------------------⌄                      
          [36mTest[39m: showtime_test.[1m[36mis_error_meta_test[39m[22m              
   [36mDescription[39m: Test failing be_error assertion with meta-data
@@ -153,30 +30,23 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
                has som lines of output                       
                Which is also followed by an io.debug()       
                                                            
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36mis_error_test[39m[22m                   
-     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
-          [36mGot[39m: [1m[31mOk(TestType(arg1: "ok", arg2: ["result"]))[39m[22m    
+       [1m[31mFailed[39m[22m: -------------------⌄                          
+         [36mTest[39m: showtime_test.[1m[36mis_ok_test[39m[22m                      
+     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
+          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
    [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_error_test                   
-               should.be_error                               
+               showtime_test.is_ok_test                      
+               should.be_ok                                  
                should.evaluate                               
                gleam.makeError                               
-       [36mOutput[39m: This test                                     
-               has som lines of output                       
-               Which is also followed by an io.debug()       
                                                            
-       [1m[31mFailed[39m[22m: -----------------------⌄                      
-         [36mTest[39m: showtime_test.[1m[36mis_false_meta_test[39m[22m              
-  [36mDescription[39m: Test is false with meta                       
-     [36mExpected[39m: [1m[32mFalse[39m[22m                                         
-          [36mGot[39m: [1m[31mTrue[39m[22m                                          
+       [1m[31mFailed[39m[22m: -------------------⌄                          
+         [36mTest[39m: showtime_test.[1m[36mother_test[39m[22m                      
+     [36mExpected[39m: [1m[32mTestType(arg1: "apa", arg2: ["älg", "skog"])[39m[22m  
+          [36mGot[39m: [1m[31mVariant[39m[22m                                       
    [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.be_false                                 
-               should.be_false_meta                          
-               should.equal_meta                             
+               showtime_test.other_test                      
+               should.equal                                  
                should.evaluate                               
                gleam.makeError                               
                                                            
@@ -191,61 +61,29 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mis_ok_meta_test[39m[22m                 
-  [36mDescription[39m: Test failing be_ok assertion with meta-data   
-     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
-          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.be_ok                                    
-               should.be_ok_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: -------------------⌄                          
-         [36mTest[39m: showtime_test.[1m[36mis_ok_test[39m[22m                      
-     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
-          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_ok_test                      
-               should.be_ok                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
        [1m[31mFailed[39m[22m: ----------------------⌄                       
-         [36mTest[39m: showtime_test.[1m[36mis_true_meta_test[39m[22m               
-  [36mDescription[39m: Test is true with meta                        
-     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
-          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+         [36mTest[39m: showtime_test.[1m[36mdiff_string_test[39m[22m                
+  [36mDescription[39m: Test diffing of strings                       
+     [36mExpected[39m: [1m[32mt[39m[22m[1m[32mh[39m[22m[1m[32me[39m[22m test t[1m[32mh[39m[22ming                                
+          [36mGot[39m: [1m[31ma[39m[22m test [1m[31ms[39m[22mt[1m[31mr[39m[22ming                                 
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
-               test.be_true                                  
-               should.be_true_meta                           
+               test.equal                                    
                should.equal_meta                             
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36mis_true_test[39m[22m                    
-     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
-          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+       [1m[31mFailed[39m[22m: ----------------------⌄                       
+         [36mTest[39m: showtime_test.[1m[36mdiff_custom_test[39m[22m                
+  [36mDescription[39m: Testing diffs of custom types                 
+     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m]
+          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
    [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_true_test                    
-               should.be_true                                
-               should.equal                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mlist_test[39m[22m                       
-     [36mExpected[39m: [3, [1m[32m4[39m[22m, [1m[32m5[39m[22m]                                     
-          [36mGot[39m: [[1m[31m1[39m[22m, [1m[31m2[39m[22m, 3]                                     
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.list_test                       
-               should.equal                                  
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.equal                                    
+               should.equal_meta                             
                should.evaluate                               
                gleam.makeError                               
                                                            
@@ -268,11 +106,157 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
                should.evaluate                               
                gleam.makeError                               
                                                            
+       [1m[31mFailed[39m[22m: -------------------------⌄                    
+         [36mTest[39m: showtime_test.[1m[36mgeneric_exception_test[39m[22m          
+     [36mExpected[39m: Exception in test function                    
+          [36mGot[39m: [1m[31mTestType(arg1: "Generic", arg2: [])[39m[22m           
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36massert_test:213[39m[22m                 
+     [36mExpected[39m: Patterns should match                         
+          [36mGot[39m: [1m[31mError("bepa")[39m[22m                                 
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.assert_test                     
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36mfail_meta_test[39m[22m                  
+  [36mDescription[39m: Test fail with meta-data                      
+     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
+          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.fail                                     
+               should.fail_meta                              
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: -----------------------------⌄                
+         [36mTest[39m: showtime_test.[1m[36mgleeunit_assert_not_equal_test[39m[22m  
+     [36mExpected[39m: [1mnot [22m"1"                                       
+          [36mGot[39m: "1"                                           
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.gleeunit_assert_not_equal_test  
+               should.not_equal                              
+               gleeunit_ffi.crash                            
+                                                           
        [1m[31mFailed[39m[22m: ------------------⌄                           
          [36mTest[39m: showtime_test.[1m[36mmeta_test[39m[22m                       
   [36mDescription[39m: This is a test description                    
      [36mExpected[39m: ["bepa", [1m[32m"depa"[39m[22m]                              
           [36mGot[39m: [[1m[31m"apa"[39m[22m, "bepa"]                               
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.equal                                    
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mdjur_test[39m[22m                       
+     [36mExpected[39m: [1mnot [22mTestType(arg1: "apa", arg2: ["ren", "tur"])
+          [36mGot[39m: TestType(arg1: "apa", arg2: ["ren", "tur"])   
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.djur_test                       
+               should.not_equal                              
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36mis_true_test[39m[22m                    
+     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
+          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.is_true_test                    
+               should.be_true                                
+               should.equal                                  
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mi_am_test[39m[22m                       
+     [36mExpected[39m: [1m[32mT[39m[22m[1m[32me[39m[22m[1m[32ms[39m[22m[1m[32mt[39m[22m[1m[32mT[39m[22m[1m[32my[39m[22m[1m[32mp[39m[22m[1m[32me[39m[22m[1m[32m([39m[22mar[1m[32mg[39m[22m[1m[32m1[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22m[1m[32mn[39m[22ma[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22m[1m[32ma[39m[22m[1m[32mr[39m[22m[1m[32mg[39m[22m[1m[32m2[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m[[39m[22m[1m[32m"[39m[22m[1m[32ms[39m[22m[1m[32mo[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22mn[1m[32ma[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m][39m[22m[1m[32m)[39m[22m
+          [36mGot[39m: [1m[31mV[39m[22mar[1m[31mi[39m[22man[1m[31mt[39m[22m                                       
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.i_am_test                       
+               should.equal                                  
+               gleeunit_ffi.crash                            
+       [36mOutput[39m: Some test output                              
+               And the some really really really really really really really really really really really really really really really really really really really really long output
+                                                           
+       [1m[31mFailed[39m[22m: ----------------------------⌄                 
+         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_error_test[39m[22m   
+     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
+          [36mGot[39m: [1m[31mOk("TestType(arg1: \"Done\", arg2: [\"good\", \"result\"])")[39m[22m
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.gleeunit_should_be_error_test   
+               should.be_error                               
+               gleeunit_ffi.crash                            
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------------⌄                  
+         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_ok_test[39m[22m      
+     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
+          [36mGot[39m: [1m[31mError("\"Wrong\"")[39m[22m                            
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.gleeunit_should_be_ok_test      
+               should.be_ok                                  
+               gleeunit_ffi.crash                            
+                                                           
+       [1m[31mFailed[39m[22m: ----------------------⌄                       
+         [36mTest[39m: showtime_test.[1m[36mis_true_meta_test[39m[22m               
+  [36mDescription[39m: Test is true with meta                        
+     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
+          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.be_true                                  
+               should.be_true_meta                           
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mfail_test[39m[22m                       
+     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
+          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.fail_test                       
+               should.fail                                   
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36mwith_meta_test[39m[22m                  
+  [36mDescription[39m: This test is defined using use                
+     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
+          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.equal                                    
+               test.equal                                    
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mlist_test[39m[22m                       
+     [36mExpected[39m: [3, [1m[32m4[39m[22m, [1m[32m5[39m[22m]                                     
+          [36mGot[39m: [[1m[31m1[39m[22m, [1m[31m2[39m[22m, 3]                                     
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.list_test                       
+               should.equal                                  
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36muse_meta_test[39m[22m                   
+  [36mDescription[39m: This test is defined using use                
+     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
+          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
@@ -294,42 +278,58 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: -------------------⌄                          
-         [36mTest[39m: showtime_test.[1m[36mother_test[39m[22m                      
-     [36mExpected[39m: [1m[32mTestType(arg1: "apa", arg2: ["älg", "skog"])[39m[22m  
-          [36mGot[39m: [1m[31mVariant[39m[22m                                       
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.other_test                      
-               should.equal                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36muse_meta_test[39m[22m                   
-  [36mDescription[39m: This test is defined using use                
-     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
-          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36mdiff_long_test[39m[22m                  
+  [36mDescription[39m: Testing long expected and got                 
+     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m]
+          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
                test.equal                                    
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: -----------------------⌄                      
+         [36mTest[39m: showtime_test.[1m[36mis_false_meta_test[39m[22m              
+  [36mDescription[39m: Test is false with meta                       
+     [36mExpected[39m: [1m[32mFalse[39m[22m                                         
+          [36mGot[39m: [1m[31mTrue[39m[22m                                          
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.be_false                                 
+               should.be_false_meta                          
                should.equal_meta                             
                should.evaluate                               
                gleam.makeError                               
                                                            
        [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mwith_meta_test[39m[22m                  
-  [36mDescription[39m: This test is defined using use                
-     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
-          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
+         [36mTest[39m: showtime_test.[1m[36mis_ok_meta_test[39m[22m                 
+  [36mDescription[39m: Test failing be_ok assertion with meta-data   
+     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
+          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
-               test.equal                                    
-               test.equal                                    
-               should.equal_meta                             
+               test.be_ok                                    
+               should.be_ok_meta                             
                should.evaluate                               
                gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36mis_error_test[39m[22m                   
+     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
+          [36mGot[39m: [1m[31mOk(TestType(arg1: "ok", arg2: ["result"]))[39m[22m    
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.is_error_test                   
+               should.be_error                               
+               should.evaluate                               
+               gleam.makeError                               
+       [36mOutput[39m: This test                                     
+               has som lines of output                       
+               Which is also followed by an io.debug()       
                                                            
        [1m[31mFailed[39m[22m: ---------------------------⌄                  
          [36mTest[39m: subfolder/sub_test.[1m[36min_subfolder_test[39m[22m          

--- a/snapshots/js_capture_mixed.txt
+++ b/snapshots/js_capture_mixed.txt
@@ -112,7 +112,7 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
           [36mGot[39m: [1m[31mTestType(arg1: "Generic", arg2: [])[39m[22m           
                                                            
        [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36massert_test:213[39m[22m                 
+         [36mTest[39m: showtime_test.[1m[36massert_test:211[39m[22m                 
      [36mExpected[39m: Patterns should match                         
           [36mGot[39m: [1m[31mError("bepa")[39m[22m                                 
    [36mStacktrace[39m: showtime_ffi.run                              

--- a/snapshots/js_capture_no.txt
+++ b/snapshots/js_capture_no.txt
@@ -14,37 +14,47 @@ has som lines of output
 Which is also followed by an io.debug()
 TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "list"])
 
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36massert_test:213[39m[22m                 
-     [36mExpected[39m: Patterns should match                         
-          [36mGot[39m: [1m[31mError("bepa")[39m[22m                                 
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.assert_test                     
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ----------------------⌄                       
-         [36mTest[39m: showtime_test.[1m[36mdiff_custom_test[39m[22m                
-  [36mDescription[39m: Testing diffs of custom types                 
-     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m]
-          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
+       [1m[31mFailed[39m[22m: -----------------------⌄                      
+         [36mTest[39m: showtime_test.[1m[36mis_error_meta_test[39m[22m              
+  [36mDescription[39m: Test failing be_error assertion with meta-data
+     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
+          [36mGot[39m: [1m[31mOk(TestType(arg1: "ok", arg2: ["result"]))[39m[22m    
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
-               test.equal                                    
-               should.equal_meta                             
+               test.be_error                                 
+               should.be_error_meta                          
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mdiff_long_test[39m[22m                  
-  [36mDescription[39m: Testing long expected and got                 
-     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m]
-          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
+       [1m[31mFailed[39m[22m: -------------------⌄                          
+         [36mTest[39m: showtime_test.[1m[36mis_ok_test[39m[22m                      
+     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
+          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
    [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.equal                                    
-               should.equal_meta                             
+               showtime_test.is_ok_test                      
+               should.be_ok                                  
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: -------------------⌄                          
+         [36mTest[39m: showtime_test.[1m[36mother_test[39m[22m                      
+     [36mExpected[39m: [1m[32mTestType(arg1: "apa", arg2: ["älg", "skog"])[39m[22m  
+          [36mGot[39m: [1m[31mVariant[39m[22m                                       
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.other_test                      
+               should.equal                                  
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36mis_false_test[39m[22m                   
+     [36mExpected[39m: [1m[32mFalse[39m[22m                                         
+          [36mGot[39m: [1m[31mTrue[39m[22m                                          
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.is_false_test                   
+               should.be_false                               
+               should.equal                                  
                should.evaluate                               
                gleam.makeError                               
                                                            
@@ -61,183 +71,16 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mdjur_test[39m[22m                       
-     [36mExpected[39m: [1mnot [22mTestType(arg1: "apa", arg2: ["ren", "tur"])
-          [36mGot[39m: TestType(arg1: "apa", arg2: ["ren", "tur"])   
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.djur_test                       
-               should.not_equal                              
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mfail_meta_test[39m[22m                  
-  [36mDescription[39m: Test fail with meta-data                      
-     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
-          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.fail                                     
-               should.fail_meta                              
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mfail_test[39m[22m                       
-     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
-          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.fail_test                       
-               should.fail                                   
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: -------------------------⌄                    
-         [36mTest[39m: showtime_test.[1m[36mgeneric_exception_test[39m[22m          
-     [36mExpected[39m: Exception in test function                    
-          [36mGot[39m: [1m[31mTestType(arg1: "Generic", arg2: [])[39m[22m           
-                                                           
-       [1m[31mFailed[39m[22m: -----------------------------⌄                
-         [36mTest[39m: showtime_test.[1m[36mgleeunit_assert_not_equal_test[39m[22m  
-     [36mExpected[39m: [1mnot [22m"1"                                       
-          [36mGot[39m: "1"                                           
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.gleeunit_assert_not_equal_test  
-               should.not_equal                              
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: ----------------------------⌄                 
-         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_error_test[39m[22m   
-     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
-          [36mGot[39m: [1m[31mOk("TestType(arg1: \"Done\", arg2: [\"good\", \"result\"])")[39m[22m
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.gleeunit_should_be_error_test   
-               should.be_error                               
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: ---------------------------⌄                  
-         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_ok_test[39m[22m      
-     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
-          [36mGot[39m: [1m[31mError("\"Wrong\"")[39m[22m                            
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.gleeunit_should_be_ok_test      
-               should.be_ok                                  
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mi_am_test[39m[22m                       
-     [36mExpected[39m: [1m[32mT[39m[22m[1m[32me[39m[22m[1m[32ms[39m[22m[1m[32mt[39m[22m[1m[32mT[39m[22m[1m[32my[39m[22m[1m[32mp[39m[22m[1m[32me[39m[22m[1m[32m([39m[22mar[1m[32mg[39m[22m[1m[32m1[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22m[1m[32mn[39m[22m[1m[32ma[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22ma[1m[32mr[39m[22m[1m[32mg[39m[22m[1m[32m2[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m[[39m[22m[1m[32m"[39m[22m[1m[32ms[39m[22m[1m[32mo[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22mn[1m[32ma[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m][39m[22m[1m[32m)[39m[22m
-          [36mGot[39m: [1m[31mV[39m[22mar[1m[31mi[39m[22man[1m[31mt[39m[22m                                       
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.i_am_test                       
-               should.equal                                  
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: -----------------------⌄                      
-         [36mTest[39m: showtime_test.[1m[36mis_error_meta_test[39m[22m              
-  [36mDescription[39m: Test failing be_error assertion with meta-data
-     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
-          [36mGot[39m: [1m[31mOk(TestType(arg1: "ok", arg2: ["result"]))[39m[22m    
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.be_error                                 
-               should.be_error_meta                          
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36mis_error_test[39m[22m                   
-     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
-          [36mGot[39m: [1m[31mOk(TestType(arg1: "ok", arg2: ["result"]))[39m[22m    
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_error_test                   
-               should.be_error                               
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: -----------------------⌄                      
-         [36mTest[39m: showtime_test.[1m[36mis_false_meta_test[39m[22m              
-  [36mDescription[39m: Test is false with meta                       
-     [36mExpected[39m: [1m[32mFalse[39m[22m                                         
-          [36mGot[39m: [1m[31mTrue[39m[22m                                          
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.be_false                                 
-               should.be_false_meta                          
-               should.equal_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36mis_false_test[39m[22m                   
-     [36mExpected[39m: [1m[32mFalse[39m[22m                                         
-          [36mGot[39m: [1m[31mTrue[39m[22m                                          
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_false_test                   
-               should.be_false                               
-               should.equal                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mis_ok_meta_test[39m[22m                 
-  [36mDescription[39m: Test failing be_ok assertion with meta-data   
-     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
-          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.be_ok                                    
-               should.be_ok_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: -------------------⌄                          
-         [36mTest[39m: showtime_test.[1m[36mis_ok_test[39m[22m                      
-     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
-          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_ok_test                      
-               should.be_ok                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
        [1m[31mFailed[39m[22m: ----------------------⌄                       
-         [36mTest[39m: showtime_test.[1m[36mis_true_meta_test[39m[22m               
-  [36mDescription[39m: Test is true with meta                        
-     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
-          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+         [36mTest[39m: showtime_test.[1m[36mdiff_custom_test[39m[22m                
+  [36mDescription[39m: Testing diffs of custom types                 
+     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m]
+          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
-               test.be_true                                  
-               should.be_true_meta                           
+               test.equal                                    
                should.equal_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36mis_true_test[39m[22m                    
-     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
-          [36mGot[39m: [1m[31mFalse[39m[22m                                         
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_true_test                    
-               should.be_true                                
-               should.equal                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mlist_test[39m[22m                       
-     [36mExpected[39m: [3, [1m[32m4[39m[22m, [1m[32m5[39m[22m]                                     
-          [36mGot[39m: [[1m[31m1[39m[22m, [1m[31m2[39m[22m, 3]                                     
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.list_test                       
-               should.equal                                  
                should.evaluate                               
                gleam.makeError                               
                                                            
@@ -260,11 +103,155 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
                should.evaluate                               
                gleam.makeError                               
                                                            
+       [1m[31mFailed[39m[22m: -------------------------⌄                    
+         [36mTest[39m: showtime_test.[1m[36mgeneric_exception_test[39m[22m          
+     [36mExpected[39m: Exception in test function                    
+          [36mGot[39m: [1m[31mTestType(arg1: "Generic", arg2: [])[39m[22m           
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36massert_test:213[39m[22m                 
+     [36mExpected[39m: Patterns should match                         
+          [36mGot[39m: [1m[31mError("bepa")[39m[22m                                 
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.assert_test                     
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36mfail_meta_test[39m[22m                  
+  [36mDescription[39m: Test fail with meta-data                      
+     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
+          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.fail                                     
+               should.fail_meta                              
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: -----------------------------⌄                
+         [36mTest[39m: showtime_test.[1m[36mgleeunit_assert_not_equal_test[39m[22m  
+     [36mExpected[39m: [1mnot [22m"1"                                       
+          [36mGot[39m: "1"                                           
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.gleeunit_assert_not_equal_test  
+               should.not_equal                              
+               gleeunit_ffi.crash                            
+                                                           
        [1m[31mFailed[39m[22m: ------------------⌄                           
          [36mTest[39m: showtime_test.[1m[36mmeta_test[39m[22m                       
   [36mDescription[39m: This is a test description                    
      [36mExpected[39m: ["bepa", [1m[32m"depa"[39m[22m]                              
           [36mGot[39m: [[1m[31m"apa"[39m[22m, "bepa"]                               
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.equal                                    
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mdjur_test[39m[22m                       
+     [36mExpected[39m: [1mnot [22mTestType(arg1: "apa", arg2: ["ren", "tur"])
+          [36mGot[39m: TestType(arg1: "apa", arg2: ["ren", "tur"])   
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.djur_test                       
+               should.not_equal                              
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36mis_true_test[39m[22m                    
+     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
+          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.is_true_test                    
+               should.be_true                                
+               should.equal                                  
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mi_am_test[39m[22m                       
+     [36mExpected[39m: [1m[32mT[39m[22m[1m[32me[39m[22m[1m[32ms[39m[22m[1m[32mt[39m[22m[1m[32mT[39m[22m[1m[32my[39m[22m[1m[32mp[39m[22m[1m[32me[39m[22m[1m[32m([39m[22mar[1m[32mg[39m[22m[1m[32m1[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22m[1m[32mn[39m[22ma[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22m[1m[32ma[39m[22m[1m[32mr[39m[22m[1m[32mg[39m[22m[1m[32m2[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m[[39m[22m[1m[32m"[39m[22m[1m[32ms[39m[22m[1m[32mo[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22mn[1m[32ma[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m][39m[22m[1m[32m)[39m[22m
+          [36mGot[39m: [1m[31mV[39m[22mar[1m[31mi[39m[22man[1m[31mt[39m[22m                                       
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.i_am_test                       
+               should.equal                                  
+               gleeunit_ffi.crash                            
+                                                           
+       [1m[31mFailed[39m[22m: ----------------------------⌄                 
+         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_error_test[39m[22m   
+     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
+          [36mGot[39m: [1m[31mOk("TestType(arg1: \"Done\", arg2: [\"good\", \"result\"])")[39m[22m
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.gleeunit_should_be_error_test   
+               should.be_error                               
+               gleeunit_ffi.crash                            
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------------⌄                  
+         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_ok_test[39m[22m      
+     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
+          [36mGot[39m: [1m[31mError("\"Wrong\"")[39m[22m                            
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.gleeunit_should_be_ok_test      
+               should.be_ok                                  
+               gleeunit_ffi.crash                            
+                                                           
+       [1m[31mFailed[39m[22m: ----------------------⌄                       
+         [36mTest[39m: showtime_test.[1m[36mis_true_meta_test[39m[22m               
+  [36mDescription[39m: Test is true with meta                        
+     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
+          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.be_true                                  
+               should.be_true_meta                           
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mfail_test[39m[22m                       
+     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
+          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.fail_test                       
+               should.fail                                   
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36mwith_meta_test[39m[22m                  
+  [36mDescription[39m: This test is defined using use                
+     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
+          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.equal                                    
+               test.equal                                    
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mlist_test[39m[22m                       
+     [36mExpected[39m: [3, [1m[32m4[39m[22m, [1m[32m5[39m[22m]                                     
+          [36mGot[39m: [[1m[31m1[39m[22m, [1m[31m2[39m[22m, 3]                                     
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.list_test                       
+               should.equal                                  
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36muse_meta_test[39m[22m                   
+  [36mDescription[39m: This test is defined using use                
+     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
+          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
@@ -286,40 +273,53 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: -------------------⌄                          
-         [36mTest[39m: showtime_test.[1m[36mother_test[39m[22m                      
-     [36mExpected[39m: [1m[32mTestType(arg1: "apa", arg2: ["älg", "skog"])[39m[22m  
-          [36mGot[39m: [1m[31mVariant[39m[22m                                       
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.other_test                      
-               should.equal                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36muse_meta_test[39m[22m                   
-  [36mDescription[39m: This test is defined using use                
-     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
-          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36mdiff_long_test[39m[22m                  
+  [36mDescription[39m: Testing long expected and got                 
+     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m]
+          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
                test.equal                                    
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: -----------------------⌄                      
+         [36mTest[39m: showtime_test.[1m[36mis_false_meta_test[39m[22m              
+  [36mDescription[39m: Test is false with meta                       
+     [36mExpected[39m: [1m[32mFalse[39m[22m                                         
+          [36mGot[39m: [1m[31mTrue[39m[22m                                          
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.be_false                                 
+               should.be_false_meta                          
                should.equal_meta                             
                should.evaluate                               
                gleam.makeError                               
                                                            
        [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mwith_meta_test[39m[22m                  
-  [36mDescription[39m: This test is defined using use                
-     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
-          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
+         [36mTest[39m: showtime_test.[1m[36mis_ok_meta_test[39m[22m                 
+  [36mDescription[39m: Test failing be_ok assertion with meta-data   
+     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
+          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
-               test.equal                                    
-               test.equal                                    
-               should.equal_meta                             
+               test.be_ok                                    
+               should.be_ok_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36mis_error_test[39m[22m                   
+     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
+          [36mGot[39m: [1m[31mOk(TestType(arg1: "ok", arg2: ["result"]))[39m[22m    
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.is_error_test                   
+               should.be_error                               
                should.evaluate                               
                gleam.makeError                               
                                                            

--- a/snapshots/js_capture_no.txt
+++ b/snapshots/js_capture_no.txt
@@ -109,7 +109,7 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
           [36mGot[39m: [1m[31mTestType(arg1: "Generic", arg2: [])[39m[22m           
                                                            
        [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36massert_test:213[39m[22m                 
+         [36mTest[39m: showtime_test.[1m[36massert_test:211[39m[22m                 
      [36mExpected[39m: Patterns should match                         
           [36mGot[39m: [1m[31mError("bepa")[39m[22m                                 
    [36mStacktrace[39m: showtime_ffi.run                              

--- a/snapshots/js_capture_yes.txt
+++ b/snapshots/js_capture_yes.txt
@@ -99,7 +99,7 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
           [36mGot[39m: [1m[31mTestType(arg1: "Generic", arg2: [])[39m[22m           
                                                            
        [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36massert_test:213[39m[22m                 
+         [36mTest[39m: showtime_test.[1m[36massert_test:211[39m[22m                 
      [36mExpected[39m: Patterns should match                         
           [36mGot[39m: [1m[31mError("bepa")[39m[22m                                 
    [36mStacktrace[39m: showtime_ffi.run                              

--- a/snapshots/js_capture_yes.txt
+++ b/snapshots/js_capture_yes.txt
@@ -1,129 +1,6 @@
 TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "list"])
 TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "list"])
 
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36massert_test:213[39m[22m                 
-     [36mExpected[39m: Patterns should match                         
-          [36mGot[39m: [1m[31mError("bepa")[39m[22m                                 
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.assert_test                     
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ----------------------⌄                       
-         [36mTest[39m: showtime_test.[1m[36mdiff_custom_test[39m[22m                
-  [36mDescription[39m: Testing diffs of custom types                 
-     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m]
-          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.equal                                    
-               should.equal_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mdiff_long_test[39m[22m                  
-  [36mDescription[39m: Testing long expected and got                 
-     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m]
-          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.equal                                    
-               should.equal_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ----------------------⌄                       
-         [36mTest[39m: showtime_test.[1m[36mdiff_string_test[39m[22m                
-  [36mDescription[39m: Test diffing of strings                       
-     [36mExpected[39m: [1m[32mt[39m[22m[1m[32mh[39m[22m[1m[32me[39m[22m test t[1m[32mh[39m[22ming                                
-          [36mGot[39m: [1m[31ma[39m[22m test [1m[31ms[39m[22mt[1m[31mr[39m[22ming                                 
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.equal                                    
-               should.equal_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mdjur_test[39m[22m                       
-     [36mExpected[39m: [1mnot [22mTestType(arg1: "apa", arg2: ["ren", "tur"])
-          [36mGot[39m: TestType(arg1: "apa", arg2: ["ren", "tur"])   
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.djur_test                       
-               should.not_equal                              
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mfail_meta_test[39m[22m                  
-  [36mDescription[39m: Test fail with meta-data                      
-     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
-          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.fail                                     
-               should.fail_meta                              
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mfail_test[39m[22m                       
-     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
-          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.fail_test                       
-               should.fail                                   
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: -------------------------⌄                    
-         [36mTest[39m: showtime_test.[1m[36mgeneric_exception_test[39m[22m          
-     [36mExpected[39m: Exception in test function                    
-          [36mGot[39m: [1m[31mTestType(arg1: "Generic", arg2: [])[39m[22m           
-                                                           
-       [1m[31mFailed[39m[22m: -----------------------------⌄                
-         [36mTest[39m: showtime_test.[1m[36mgleeunit_assert_not_equal_test[39m[22m  
-     [36mExpected[39m: [1mnot [22m"1"                                       
-          [36mGot[39m: "1"                                           
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.gleeunit_assert_not_equal_test  
-               should.not_equal                              
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: ----------------------------⌄                 
-         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_error_test[39m[22m   
-     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
-          [36mGot[39m: [1m[31mOk("TestType(arg1: \"Done\", arg2: [\"good\", \"result\"])")[39m[22m
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.gleeunit_should_be_error_test   
-               should.be_error                               
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: ---------------------------⌄                  
-         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_ok_test[39m[22m      
-     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
-          [36mGot[39m: [1m[31mError("\"Wrong\"")[39m[22m                            
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.gleeunit_should_be_ok_test      
-               should.be_ok                                  
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mi_am_test[39m[22m                       
-     [36mExpected[39m: [1m[32mT[39m[22m[1m[32me[39m[22m[1m[32ms[39m[22m[1m[32mt[39m[22m[1m[32mT[39m[22m[1m[32my[39m[22m[1m[32mp[39m[22m[1m[32me[39m[22m[1m[32m([39m[22mar[1m[32mg[39m[22m[1m[32m1[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22m[1m[32mn[39m[22m[1m[32ma[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22ma[1m[32mr[39m[22m[1m[32mg[39m[22m[1m[32m2[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m[[39m[22m[1m[32m"[39m[22m[1m[32ms[39m[22m[1m[32mo[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22mn[1m[32ma[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m][39m[22m[1m[32m)[39m[22m
-          [36mGot[39m: [1m[31mV[39m[22mar[1m[31mi[39m[22man[1m[31mt[39m[22m                                       
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.i_am_test                       
-               should.equal                                  
-               gleeunit_ffi.crash                            
-       [36mOutput[39m: Some test output                              
-               And the some really really really really really really really really really really really really really really really really really really really really long output
-                                                           
        [1m[31mFailed[39m[22m: -----------------------⌄                      
          [36mTest[39m: showtime_test.[1m[36mis_error_meta_test[39m[22m              
   [36mDescription[39m: Test failing be_error assertion with meta-data
@@ -140,30 +17,23 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
                has som lines of output                       
                Which is also followed by an io.debug()       
                                                            
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36mis_error_test[39m[22m                   
-     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
-          [36mGot[39m: [1m[31mOk(TestType(arg1: "ok", arg2: ["result"]))[39m[22m    
+       [1m[31mFailed[39m[22m: -------------------⌄                          
+         [36mTest[39m: showtime_test.[1m[36mis_ok_test[39m[22m                      
+     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
+          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
    [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_error_test                   
-               should.be_error                               
+               showtime_test.is_ok_test                      
+               should.be_ok                                  
                should.evaluate                               
                gleam.makeError                               
-       [36mOutput[39m: This test                                     
-               has som lines of output                       
-               Which is also followed by an io.debug()       
                                                            
-       [1m[31mFailed[39m[22m: -----------------------⌄                      
-         [36mTest[39m: showtime_test.[1m[36mis_false_meta_test[39m[22m              
-  [36mDescription[39m: Test is false with meta                       
-     [36mExpected[39m: [1m[32mFalse[39m[22m                                         
-          [36mGot[39m: [1m[31mTrue[39m[22m                                          
+       [1m[31mFailed[39m[22m: -------------------⌄                          
+         [36mTest[39m: showtime_test.[1m[36mother_test[39m[22m                      
+     [36mExpected[39m: [1m[32mTestType(arg1: "apa", arg2: ["älg", "skog"])[39m[22m  
+          [36mGot[39m: [1m[31mVariant[39m[22m                                       
    [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.be_false                                 
-               should.be_false_meta                          
-               should.equal_meta                             
+               showtime_test.other_test                      
+               should.equal                                  
                should.evaluate                               
                gleam.makeError                               
                                                            
@@ -178,61 +48,29 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mis_ok_meta_test[39m[22m                 
-  [36mDescription[39m: Test failing be_ok assertion with meta-data   
-     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
-          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.be_ok                                    
-               should.be_ok_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: -------------------⌄                          
-         [36mTest[39m: showtime_test.[1m[36mis_ok_test[39m[22m                      
-     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
-          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_ok_test                      
-               should.be_ok                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
        [1m[31mFailed[39m[22m: ----------------------⌄                       
-         [36mTest[39m: showtime_test.[1m[36mis_true_meta_test[39m[22m               
-  [36mDescription[39m: Test is true with meta                        
-     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
-          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+         [36mTest[39m: showtime_test.[1m[36mdiff_string_test[39m[22m                
+  [36mDescription[39m: Test diffing of strings                       
+     [36mExpected[39m: [1m[32mt[39m[22m[1m[32mh[39m[22m[1m[32me[39m[22m test t[1m[32mh[39m[22ming                                
+          [36mGot[39m: [1m[31ma[39m[22m test [1m[31ms[39m[22mt[1m[31mr[39m[22ming                                 
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
-               test.be_true                                  
-               should.be_true_meta                           
+               test.equal                                    
                should.equal_meta                             
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36mis_true_test[39m[22m                    
-     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
-          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+       [1m[31mFailed[39m[22m: ----------------------⌄                       
+         [36mTest[39m: showtime_test.[1m[36mdiff_custom_test[39m[22m                
+  [36mDescription[39m: Testing diffs of custom types                 
+     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m]
+          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
    [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_true_test                    
-               should.be_true                                
-               should.equal                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mlist_test[39m[22m                       
-     [36mExpected[39m: [3, [1m[32m4[39m[22m, [1m[32m5[39m[22m]                                     
-          [36mGot[39m: [[1m[31m1[39m[22m, [1m[31m2[39m[22m, 3]                                     
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.list_test                       
-               should.equal                                  
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.equal                                    
+               should.equal_meta                             
                should.evaluate                               
                gleam.makeError                               
                                                            
@@ -255,11 +93,157 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
                should.evaluate                               
                gleam.makeError                               
                                                            
+       [1m[31mFailed[39m[22m: -------------------------⌄                    
+         [36mTest[39m: showtime_test.[1m[36mgeneric_exception_test[39m[22m          
+     [36mExpected[39m: Exception in test function                    
+          [36mGot[39m: [1m[31mTestType(arg1: "Generic", arg2: [])[39m[22m           
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36massert_test:213[39m[22m                 
+     [36mExpected[39m: Patterns should match                         
+          [36mGot[39m: [1m[31mError("bepa")[39m[22m                                 
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.assert_test                     
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36mfail_meta_test[39m[22m                  
+  [36mDescription[39m: Test fail with meta-data                      
+     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
+          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.fail                                     
+               should.fail_meta                              
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: -----------------------------⌄                
+         [36mTest[39m: showtime_test.[1m[36mgleeunit_assert_not_equal_test[39m[22m  
+     [36mExpected[39m: [1mnot [22m"1"                                       
+          [36mGot[39m: "1"                                           
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.gleeunit_assert_not_equal_test  
+               should.not_equal                              
+               gleeunit_ffi.crash                            
+                                                           
        [1m[31mFailed[39m[22m: ------------------⌄                           
          [36mTest[39m: showtime_test.[1m[36mmeta_test[39m[22m                       
   [36mDescription[39m: This is a test description                    
      [36mExpected[39m: ["bepa", [1m[32m"depa"[39m[22m]                              
           [36mGot[39m: [[1m[31m"apa"[39m[22m, "bepa"]                               
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.equal                                    
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mdjur_test[39m[22m                       
+     [36mExpected[39m: [1mnot [22mTestType(arg1: "apa", arg2: ["ren", "tur"])
+          [36mGot[39m: TestType(arg1: "apa", arg2: ["ren", "tur"])   
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.djur_test                       
+               should.not_equal                              
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36mis_true_test[39m[22m                    
+     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
+          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.is_true_test                    
+               should.be_true                                
+               should.equal                                  
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mi_am_test[39m[22m                       
+     [36mExpected[39m: [1m[32mT[39m[22m[1m[32me[39m[22m[1m[32ms[39m[22m[1m[32mt[39m[22m[1m[32mT[39m[22m[1m[32my[39m[22m[1m[32mp[39m[22m[1m[32me[39m[22m[1m[32m([39m[22mar[1m[32mg[39m[22m[1m[32m1[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22m[1m[32mn[39m[22ma[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22m[1m[32ma[39m[22m[1m[32mr[39m[22m[1m[32mg[39m[22m[1m[32m2[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m[[39m[22m[1m[32m"[39m[22m[1m[32ms[39m[22m[1m[32mo[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22mn[1m[32ma[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m][39m[22m[1m[32m)[39m[22m
+          [36mGot[39m: [1m[31mV[39m[22mar[1m[31mi[39m[22man[1m[31mt[39m[22m                                       
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.i_am_test                       
+               should.equal                                  
+               gleeunit_ffi.crash                            
+       [36mOutput[39m: Some test output                              
+               And the some really really really really really really really really really really really really really really really really really really really really long output
+                                                           
+       [1m[31mFailed[39m[22m: ----------------------------⌄                 
+         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_error_test[39m[22m   
+     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
+          [36mGot[39m: [1m[31mOk("TestType(arg1: \"Done\", arg2: [\"good\", \"result\"])")[39m[22m
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.gleeunit_should_be_error_test   
+               should.be_error                               
+               gleeunit_ffi.crash                            
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------------⌄                  
+         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_ok_test[39m[22m      
+     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
+          [36mGot[39m: [1m[31mError("\"Wrong\"")[39m[22m                            
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.gleeunit_should_be_ok_test      
+               should.be_ok                                  
+               gleeunit_ffi.crash                            
+                                                           
+       [1m[31mFailed[39m[22m: ----------------------⌄                       
+         [36mTest[39m: showtime_test.[1m[36mis_true_meta_test[39m[22m               
+  [36mDescription[39m: Test is true with meta                        
+     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
+          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.be_true                                  
+               should.be_true_meta                           
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mfail_test[39m[22m                       
+     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
+          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.fail_test                       
+               should.fail                                   
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36mwith_meta_test[39m[22m                  
+  [36mDescription[39m: This test is defined using use                
+     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
+          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.equal                                    
+               test.equal                                    
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mlist_test[39m[22m                       
+     [36mExpected[39m: [3, [1m[32m4[39m[22m, [1m[32m5[39m[22m]                                     
+          [36mGot[39m: [[1m[31m1[39m[22m, [1m[31m2[39m[22m, 3]                                     
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.list_test                       
+               should.equal                                  
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36muse_meta_test[39m[22m                   
+  [36mDescription[39m: This test is defined using use                
+     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
+          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
@@ -281,42 +265,58 @@ TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "lis
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: -------------------⌄                          
-         [36mTest[39m: showtime_test.[1m[36mother_test[39m[22m                      
-     [36mExpected[39m: [1m[32mTestType(arg1: "apa", arg2: ["älg", "skog"])[39m[22m  
-          [36mGot[39m: [1m[31mVariant[39m[22m                                       
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.other_test                      
-               should.equal                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36muse_meta_test[39m[22m                   
-  [36mDescription[39m: This test is defined using use                
-     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
-          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36mdiff_long_test[39m[22m                  
+  [36mDescription[39m: Testing long expected and got                 
+     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m]
+          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
                test.equal                                    
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: -----------------------⌄                      
+         [36mTest[39m: showtime_test.[1m[36mis_false_meta_test[39m[22m              
+  [36mDescription[39m: Test is false with meta                       
+     [36mExpected[39m: [1m[32mFalse[39m[22m                                         
+          [36mGot[39m: [1m[31mTrue[39m[22m                                          
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.be_false                                 
+               should.be_false_meta                          
                should.equal_meta                             
                should.evaluate                               
                gleam.makeError                               
                                                            
        [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mwith_meta_test[39m[22m                  
-  [36mDescription[39m: This test is defined using use                
-     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
-          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
+         [36mTest[39m: showtime_test.[1m[36mis_ok_meta_test[39m[22m                 
+  [36mDescription[39m: Test failing be_ok assertion with meta-data   
+     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
+          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
-               test.equal                                    
-               test.equal                                    
-               should.equal_meta                             
+               test.be_ok                                    
+               should.be_ok_meta                             
                should.evaluate                               
                gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36mis_error_test[39m[22m                   
+     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
+          [36mGot[39m: [1m[31mOk(TestType(arg1: "ok", arg2: ["result"]))[39m[22m    
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.is_error_test                   
+               should.be_error                               
+               should.evaluate                               
+               gleam.makeError                               
+       [36mOutput[39m: This test                                     
+               has som lines of output                       
+               Which is also followed by an io.debug()       
                                                            
        [1m[31mFailed[39m[22m: ---------------------------⌄                  
          [36mTest[39m: subfolder/sub_test.[1m[36min_subfolder_test[39m[22m          

--- a/snapshots/js_ignore_ignore.txt
+++ b/snapshots/js_ignore_ignore.txt
@@ -13,37 +13,47 @@ Which is also followed by an io.debug()
 TestType(arg1: "Im the infamous TestType", arg2: ["we", "are", "on", "the", "list"])
 Ignoring: meta_test
 
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36massert_test:213[39m[22m                 
-     [36mExpected[39m: Patterns should match                         
-          [36mGot[39m: [1m[31mError("bepa")[39m[22m                                 
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.assert_test                     
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ----------------------⌄                       
-         [36mTest[39m: showtime_test.[1m[36mdiff_custom_test[39m[22m                
-  [36mDescription[39m: Testing diffs of custom types                 
-     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m]
-          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
+       [1m[31mFailed[39m[22m: -----------------------⌄                      
+         [36mTest[39m: showtime_test.[1m[36mis_error_meta_test[39m[22m              
+  [36mDescription[39m: Test failing be_error assertion with meta-data
+     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
+          [36mGot[39m: [1m[31mOk(TestType(arg1: "ok", arg2: ["result"]))[39m[22m    
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
-               test.equal                                    
-               should.equal_meta                             
+               test.be_error                                 
+               should.be_error_meta                          
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mdiff_long_test[39m[22m                  
-  [36mDescription[39m: Testing long expected and got                 
-     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m]
-          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
+       [1m[31mFailed[39m[22m: -------------------⌄                          
+         [36mTest[39m: showtime_test.[1m[36mis_ok_test[39m[22m                      
+     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
+          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
    [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.equal                                    
-               should.equal_meta                             
+               showtime_test.is_ok_test                      
+               should.be_ok                                  
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: -------------------⌄                          
+         [36mTest[39m: showtime_test.[1m[36mother_test[39m[22m                      
+     [36mExpected[39m: [1m[32mTestType(arg1: "apa", arg2: ["älg", "skog"])[39m[22m  
+          [36mGot[39m: [1m[31mVariant[39m[22m                                       
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.other_test                      
+               should.equal                                  
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36mis_false_test[39m[22m                   
+     [36mExpected[39m: [1m[32mFalse[39m[22m                                         
+          [36mGot[39m: [1m[31mTrue[39m[22m                                          
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.is_false_test                   
+               should.be_false                               
+               should.equal                                  
                should.evaluate                               
                gleam.makeError                               
                                                            
@@ -60,183 +70,16 @@ Ignoring: meta_test
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mdjur_test[39m[22m                       
-     [36mExpected[39m: [1mnot [22mTestType(arg1: "apa", arg2: ["ren", "tur"])
-          [36mGot[39m: TestType(arg1: "apa", arg2: ["ren", "tur"])   
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.djur_test                       
-               should.not_equal                              
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mfail_meta_test[39m[22m                  
-  [36mDescription[39m: Test fail with meta-data                      
-     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
-          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.fail                                     
-               should.fail_meta                              
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mfail_test[39m[22m                       
-     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
-          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.fail_test                       
-               should.fail                                   
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: -------------------------⌄                    
-         [36mTest[39m: showtime_test.[1m[36mgeneric_exception_test[39m[22m          
-     [36mExpected[39m: Exception in test function                    
-          [36mGot[39m: [1m[31mTestType(arg1: "Generic", arg2: [])[39m[22m           
-                                                           
-       [1m[31mFailed[39m[22m: -----------------------------⌄                
-         [36mTest[39m: showtime_test.[1m[36mgleeunit_assert_not_equal_test[39m[22m  
-     [36mExpected[39m: [1mnot [22m"1"                                       
-          [36mGot[39m: "1"                                           
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.gleeunit_assert_not_equal_test  
-               should.not_equal                              
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: ----------------------------⌄                 
-         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_error_test[39m[22m   
-     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
-          [36mGot[39m: [1m[31mOk("TestType(arg1: \"Done\", arg2: [\"good\", \"result\"])")[39m[22m
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.gleeunit_should_be_error_test   
-               should.be_error                               
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: ---------------------------⌄                  
-         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_ok_test[39m[22m      
-     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
-          [36mGot[39m: [1m[31mError("\"Wrong\"")[39m[22m                            
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.gleeunit_should_be_ok_test      
-               should.be_ok                                  
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mi_am_test[39m[22m                       
-     [36mExpected[39m: [1m[32mT[39m[22m[1m[32me[39m[22m[1m[32ms[39m[22m[1m[32mt[39m[22m[1m[32mT[39m[22m[1m[32my[39m[22m[1m[32mp[39m[22m[1m[32me[39m[22m[1m[32m([39m[22mar[1m[32mg[39m[22m[1m[32m1[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22m[1m[32mn[39m[22m[1m[32ma[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22ma[1m[32mr[39m[22m[1m[32mg[39m[22m[1m[32m2[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m[[39m[22m[1m[32m"[39m[22m[1m[32ms[39m[22m[1m[32mo[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22mn[1m[32ma[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m][39m[22m[1m[32m)[39m[22m
-          [36mGot[39m: [1m[31mV[39m[22mar[1m[31mi[39m[22man[1m[31mt[39m[22m                                       
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.i_am_test                       
-               should.equal                                  
-               gleeunit_ffi.crash                            
-                                                           
-       [1m[31mFailed[39m[22m: -----------------------⌄                      
-         [36mTest[39m: showtime_test.[1m[36mis_error_meta_test[39m[22m              
-  [36mDescription[39m: Test failing be_error assertion with meta-data
-     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
-          [36mGot[39m: [1m[31mOk(TestType(arg1: "ok", arg2: ["result"]))[39m[22m    
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.be_error                                 
-               should.be_error_meta                          
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36mis_error_test[39m[22m                   
-     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
-          [36mGot[39m: [1m[31mOk(TestType(arg1: "ok", arg2: ["result"]))[39m[22m    
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_error_test                   
-               should.be_error                               
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: -----------------------⌄                      
-         [36mTest[39m: showtime_test.[1m[36mis_false_meta_test[39m[22m              
-  [36mDescription[39m: Test is false with meta                       
-     [36mExpected[39m: [1m[32mFalse[39m[22m                                         
-          [36mGot[39m: [1m[31mTrue[39m[22m                                          
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.be_false                                 
-               should.be_false_meta                          
-               should.equal_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36mis_false_test[39m[22m                   
-     [36mExpected[39m: [1m[32mFalse[39m[22m                                         
-          [36mGot[39m: [1m[31mTrue[39m[22m                                          
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_false_test                   
-               should.be_false                               
-               should.equal                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mis_ok_meta_test[39m[22m                 
-  [36mDescription[39m: Test failing be_ok assertion with meta-data   
-     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
-          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
-   [36mStacktrace[39m: showtime_ffi.run                              
-               test.test_function                            
-               showtime_test.(anonymous)                     
-               test.be_ok                                    
-               should.be_ok_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: -------------------⌄                          
-         [36mTest[39m: showtime_test.[1m[36mis_ok_test[39m[22m                      
-     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
-          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_ok_test                      
-               should.be_ok                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
        [1m[31mFailed[39m[22m: ----------------------⌄                       
-         [36mTest[39m: showtime_test.[1m[36mis_true_meta_test[39m[22m               
-  [36mDescription[39m: Test is true with meta                        
-     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
-          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+         [36mTest[39m: showtime_test.[1m[36mdiff_custom_test[39m[22m                
+  [36mDescription[39m: Testing diffs of custom types                 
+     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m]
+          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
-               test.be_true                                  
-               should.be_true_meta                           
+               test.equal                                    
                should.equal_meta                             
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: --------------------⌄                         
-         [36mTest[39m: showtime_test.[1m[36mis_true_test[39m[22m                    
-     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
-          [36mGot[39m: [1m[31mFalse[39m[22m                                         
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.is_true_test                    
-               should.be_true                                
-               should.equal                                  
-               should.evaluate                               
-               gleam.makeError                               
-                                                           
-       [1m[31mFailed[39m[22m: ------------------⌄                           
-         [36mTest[39m: showtime_test.[1m[36mlist_test[39m[22m                       
-     [36mExpected[39m: [3, [1m[32m4[39m[22m, [1m[32m5[39m[22m]                                     
-          [36mGot[39m: [[1m[31m1[39m[22m, [1m[31m2[39m[22m, 3]                                     
-   [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.list_test                       
-               should.equal                                  
                should.evaluate                               
                gleam.makeError                               
                                                            
@@ -259,25 +102,133 @@ Ignoring: meta_test
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: -----------------------⌄                      
-         [36mTest[39m: showtime_test.[1m[36mnot_equal_meta_test[39m[22m             
-  [36mDescription[39m: Test if meta works for not_equal              
-     [36mExpected[39m: [1m[32mTestType(arg1: "apa", arg2: ["ren", "flax"])[39m[22m  
-          [36mGot[39m: [1m[31mTestType(arg1: "apa", arg2: ["ren", "tur"])[39m[22m   
+       [1m[31mFailed[39m[22m: -------------------------⌄                    
+         [36mTest[39m: showtime_test.[1m[36mgeneric_exception_test[39m[22m          
+     [36mExpected[39m: Exception in test function                    
+          [36mGot[39m: [1m[31mTestType(arg1: "Generic", arg2: [])[39m[22m           
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36massert_test:213[39m[22m                 
+     [36mExpected[39m: Patterns should match                         
+          [36mGot[39m: [1m[31mError("bepa")[39m[22m                                 
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.assert_test                     
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36mfail_meta_test[39m[22m                  
+  [36mDescription[39m: Test fail with meta-data                      
+     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
+          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
-               test.not_equal                                
+               test.fail                                     
+               should.fail_meta                              
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: -----------------------------⌄                
+         [36mTest[39m: showtime_test.[1m[36mgleeunit_assert_not_equal_test[39m[22m  
+     [36mExpected[39m: [1mnot [22m"1"                                       
+          [36mGot[39m: "1"                                           
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.gleeunit_assert_not_equal_test  
+               should.not_equal                              
+               gleeunit_ffi.crash                            
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mdjur_test[39m[22m                       
+     [36mExpected[39m: [1mnot [22mTestType(arg1: "apa", arg2: ["ren", "tur"])
+          [36mGot[39m: TestType(arg1: "apa", arg2: ["ren", "tur"])   
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.djur_test                       
+               should.not_equal                              
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36mis_true_test[39m[22m                    
+     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
+          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.is_true_test                    
+               should.be_true                                
+               should.equal                                  
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mi_am_test[39m[22m                       
+     [36mExpected[39m: [1m[32mT[39m[22m[1m[32me[39m[22m[1m[32ms[39m[22m[1m[32mt[39m[22m[1m[32mT[39m[22m[1m[32my[39m[22m[1m[32mp[39m[22m[1m[32me[39m[22m[1m[32m([39m[22mar[1m[32mg[39m[22m[1m[32m1[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22m[1m[32mn[39m[22ma[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22m[1m[32ma[39m[22m[1m[32mr[39m[22m[1m[32mg[39m[22m[1m[32m2[39m[22m[1m[32m:[39m[22m[1m[32m [39m[22m[1m[32m[[39m[22m[1m[32m"[39m[22m[1m[32ms[39m[22m[1m[32mo[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m,[39m[22m[1m[32m [39m[22m[1m[32m"[39m[22mn[1m[32ma[39m[22m[1m[32mm[39m[22m[1m[32me[39m[22m[1m[32m"[39m[22m[1m[32m][39m[22m[1m[32m)[39m[22m
+          [36mGot[39m: [1m[31mV[39m[22mar[1m[31mi[39m[22man[1m[31mt[39m[22m                                       
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.i_am_test                       
+               should.equal                                  
+               gleeunit_ffi.crash                            
+                                                           
+       [1m[31mFailed[39m[22m: ----------------------------⌄                 
+         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_error_test[39m[22m   
+     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
+          [36mGot[39m: [1m[31mOk("TestType(arg1: \"Done\", arg2: [\"good\", \"result\"])")[39m[22m
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.gleeunit_should_be_error_test   
+               should.be_error                               
+               gleeunit_ffi.crash                            
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------------⌄                  
+         [36mTest[39m: showtime_test.[1m[36mgleeunit_should_be_ok_test[39m[22m      
+     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
+          [36mGot[39m: [1m[31mError("\"Wrong\"")[39m[22m                            
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.gleeunit_should_be_ok_test      
+               should.be_ok                                  
+               gleeunit_ffi.crash                            
+                                                           
+       [1m[31mFailed[39m[22m: ----------------------⌄                       
+         [36mTest[39m: showtime_test.[1m[36mis_true_meta_test[39m[22m               
+  [36mDescription[39m: Test is true with meta                        
+     [36mExpected[39m: [1m[32mTrue[39m[22m                                          
+          [36mGot[39m: [1m[31mFalse[39m[22m                                         
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.be_true                                  
+               should.be_true_meta                           
                should.equal_meta                             
                should.evaluate                               
                gleam.makeError                               
                                                            
-       [1m[31mFailed[39m[22m: -------------------⌄                          
-         [36mTest[39m: showtime_test.[1m[36mother_test[39m[22m                      
-     [36mExpected[39m: [1m[32mTestType(arg1: "apa", arg2: ["älg", "skog"])[39m[22m  
-          [36mGot[39m: [1m[31mVariant[39m[22m                                       
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mfail_test[39m[22m                       
+     [36mExpected[39m: [1m[31mshould.fail()[39m[22m                                 
+          [36mGot[39m: [1m[31mN/A - test always expected to fail[39m[22m            
    [36mStacktrace[39m: showtime_ffi.run                              
-               showtime_test.other_test                      
+               showtime_test.fail_test                       
+               should.fail                                   
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36mwith_meta_test[39m[22m                  
+  [36mDescription[39m: This test is defined using use                
+     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
+          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.equal                                    
+               test.equal                                    
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ------------------⌄                           
+         [36mTest[39m: showtime_test.[1m[36mlist_test[39m[22m                       
+     [36mExpected[39m: [3, [1m[32m4[39m[22m, [1m[32m5[39m[22m]                                     
+          [36mGot[39m: [[1m[31m1[39m[22m, [1m[31m2[39m[22m, 3]                                     
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.list_test                       
                should.equal                                  
                should.evaluate                               
                gleam.makeError                               
@@ -295,17 +246,66 @@ Ignoring: meta_test
                should.evaluate                               
                gleam.makeError                               
                                                            
+       [1m[31mFailed[39m[22m: -----------------------⌄                      
+         [36mTest[39m: showtime_test.[1m[36mnot_equal_meta_test[39m[22m             
+  [36mDescription[39m: Test if meta works for not_equal              
+     [36mExpected[39m: [1m[32mTestType(arg1: "apa", arg2: ["ren", "flax"])[39m[22m  
+          [36mGot[39m: [1m[31mTestType(arg1: "apa", arg2: ["ren", "tur"])[39m[22m   
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.not_equal                                
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
        [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36mwith_meta_test[39m[22m                  
-  [36mDescription[39m: This test is defined using use                
-     [36mExpected[39m: [1m[32mu[39m[22m[1m[32mn[39m[22m[1m[32mi[39m[22m[1m[32mv[39m[22me[1m[32mr[39m[22m[1m[32ms[39m[22m[1m[32me[39m[22m                                      
-          [36mGot[39m: [1m[31mm[39m[22me[1m[31mt[39m[22m[1m[31ma[39m[22m                                          
+         [36mTest[39m: showtime_test.[1m[36mdiff_long_test[39m[22m                  
+  [36mDescription[39m: Testing long expected and got                 
+     [36mExpected[39m: [TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, [1m[32mVariant[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[32mTestType(arg1: "first", arg2: ["other", "array"])[39m[22m]
+          [36mGot[39m: [[1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"]), [1m[31mTestType(arg1: "first", arg2: ["in", "array"])[39m[22m, TestType(arg1: "second", arg2: ["in", "array"])]
    [36mStacktrace[39m: showtime_ffi.run                              
                test.test_function                            
                showtime_test.(anonymous)                     
                test.equal                                    
-               test.equal                                    
                should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: -----------------------⌄                      
+         [36mTest[39m: showtime_test.[1m[36mis_false_meta_test[39m[22m              
+  [36mDescription[39m: Test is false with meta                       
+     [36mExpected[39m: [1m[32mFalse[39m[22m                                         
+          [36mGot[39m: [1m[31mTrue[39m[22m                                          
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.be_false                                 
+               should.be_false_meta                          
+               should.equal_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: ---------------------⌄                        
+         [36mTest[39m: showtime_test.[1m[36mis_ok_meta_test[39m[22m                 
+  [36mDescription[39m: Test failing be_ok assertion with meta-data   
+     [36mExpected[39m: [1m[32mOk(_)[39m[22m                                         
+          [36mGot[39m: [1m[31mError(TestType(arg1: "error", arg2: ["caused", "by"]))[39m[22m
+   [36mStacktrace[39m: showtime_ffi.run                              
+               test.test_function                            
+               showtime_test.(anonymous)                     
+               test.be_ok                                    
+               should.be_ok_meta                             
+               should.evaluate                               
+               gleam.makeError                               
+                                                           
+       [1m[31mFailed[39m[22m: --------------------⌄                         
+         [36mTest[39m: showtime_test.[1m[36mis_error_test[39m[22m                   
+     [36mExpected[39m: [1m[32mError(_)[39m[22m                                      
+          [36mGot[39m: [1m[31mOk(TestType(arg1: "ok", arg2: ["result"]))[39m[22m    
+   [36mStacktrace[39m: showtime_ffi.run                              
+               showtime_test.is_error_test                   
+               should.be_error                               
                should.evaluate                               
                gleam.makeError                               
                                                            

--- a/snapshots/js_ignore_ignore.txt
+++ b/snapshots/js_ignore_ignore.txt
@@ -108,7 +108,7 @@ Ignoring: meta_test
           [36mGot[39m: [1m[31mTestType(arg1: "Generic", arg2: [])[39m[22m           
                                                            
        [1m[31mFailed[39m[22m: ---------------------⌄                        
-         [36mTest[39m: showtime_test.[1m[36massert_test:213[39m[22m                 
+         [36mTest[39m: showtime_test.[1m[36massert_test:211[39m[22m                 
      [36mExpected[39m: Patterns should match                         
           [36mGot[39m: [1m[31mError("bepa")[39m[22m                                 
    [36mStacktrace[39m: showtime_ffi.run                              

--- a/src/showtime.gleam
+++ b/src/showtime.gleam
@@ -22,6 +22,8 @@ import showtime/internal/erlang/runner
 import showtime/internal/erlang/discover.{
   collect_modules, collect_test_functions,
 }
+@target(javascript)
+import gleam/io
 
 @target(erlang)
 pub fn main() {
@@ -143,7 +145,7 @@ fn event_handler(event: TestEvent, state: HandlerState) {
 @external(javascript, "./showtime_ffi.mjs", "run")
 fn run_tests(a: fn(TestEvent, HandlerState) -> HandlerState, b: HandlerState, c: Option(
     List(String),
-  ), d: List(String), e: Capture) -> Nil
+  ), d: List(String), e: cli.Capture) -> Nil
 
 @target(javascript)
 @external(javascript, "./showtime_ffi.mjs", "start_args")

--- a/src/showtime.gleam
+++ b/src/showtime.gleam
@@ -1,15 +1,13 @@
 import glint.{CommandInput, flag}
-import glint/flag.{LS, S}
+import glint/flag
 import glint/flag/constraint.{one_of}
 import gleam/result
 import gleam/string
-import gleam/io
-import snag
-import showtime/internal/common/cli.{Capture, Mixed, No, Yes}
+import showtime/internal/common/cli.{Mixed, No, Yes}
 @target(erlang)
 import gleam/list
 @target(erlang)
-import gleam/option.{None, Option, Some}
+import gleam/option.{None, Some}
 @target(erlang)
 import gleam/erlang.{start_arguments}
 @target(erlang)

--- a/src/showtime.gleam
+++ b/src/showtime.gleam
@@ -1,192 +1,222 @@
-import glint.{CommandInput}
+import glint.{CommandInput, flag}
 import glint/flag.{LS, S}
+import glint/flag/constraint.{one_of}
 import gleam/result
 import gleam/string
 import gleam/io
 import snag
 import showtime/internal/common/cli.{Capture, Mixed, No, Yes}
-
-if erlang {
-  import gleam/list
-  import gleam/option.{None, Option, Some}
-  import gleam/erlang.{start_arguments}
-  import showtime/internal/common/test_suite.{EndTestRun, StartTestRun}
-  import showtime/internal/erlang/event_handler
-  import showtime/internal/erlang/module_handler
-  import showtime/internal/erlang/runner
-  import showtime/internal/erlang/discover.{
-    collect_modules, collect_test_functions,
-  }
-
-  pub fn main() {
-    start_with_args(start_arguments(), run)
-  }
-
-  fn run(
-    module_list: Option(List(String)),
-    ignore_tags: List(String),
-    capture: Capture,
-  ) {
-    // Start event handler which will collect test-results and eventually
-    // print test report
-    let test_event_handler = event_handler.start()
-    // Start module handler which receives msg about modules to test and
-    // runs the test-suite for the module
-    let test_module_handler =
-      module_handler.start(
-        test_event_handler,
-        collect_test_functions,
-        runner.run_test_suite,
-        ignore_tags,
-        capture,
-      )
-
-    test_event_handler(StartTestRun)
-    // Collect modules and notify the module handler to start the test-suites
-    let modules = collect_modules(test_module_handler, module_list)
-    test_event_handler(EndTestRun(
-      modules
-      |> list.length(),
-    ))
-    Nil
-  }
+@target(erlang)
+import gleam/list
+@target(erlang)
+import gleam/option.{None, Option, Some}
+@target(erlang)
+import gleam/erlang.{start_arguments}
+@target(erlang)
+import showtime/internal/common/test_suite.{EndTestRun, StartTestRun}
+@target(erlang)
+import showtime/internal/erlang/event_handler
+@target(erlang)
+import showtime/internal/erlang/module_handler
+@target(erlang)
+import showtime/internal/erlang/runner
+@target(erlang)
+import showtime/internal/erlang/discover.{
+  collect_modules, collect_test_functions,
 }
 
-if javascript {
-  import gleam/map
-  import gleam/option.{None, Option, Some}
-  import showtime/internal/common/test_suite.{TestEvent}
-  import showtime/internal/common/common_event_handler.{
-    Finished, HandlerState, NotStarted, handle_event,
-  }
-  import showtime/internal/reports/formatter.{create_test_report}
-
-  pub fn main() {
-    start_with_args(start_arguments(), run)
-  }
-
-  fn run(
-    module_list: Option(List(String)),
-    ignore_tags: List(String),
-    capture: Capture,
-  ) {
-    // Find test modules and run the tests using the event-handler for
-    // collecting test-results and eventually print a test-report
-    run_tests(
-      event_handler,
-      HandlerState(NotStarted, 0, map.new()),
-      module_list,
+@target(erlang)
+pub fn main() {
+  use module_list, ignore_tags, capture <- start_with_args(start_arguments())
+  // Start event handler which will collect test-results and eventually
+  // print test report
+  let test_event_handler = event_handler.start()
+  // Start module handler which receives msg about modules to test and
+  // runs the test-suite for the module
+  let test_module_handler =
+    module_handler.start(
+      test_event_handler,
+      collect_test_functions,
+      runner.run_test_suite,
       ignore_tags,
       capture,
     )
-  }
 
-  fn event_handler(event: TestEvent, state: HandlerState) {
-    let new_state = handle_event(event, system_time, state)
-    case new_state {
-      HandlerState(Finished(_), _, events) -> {
-        let #(report, num_failed) = create_test_report(events)
-        io.println(report)
-        case num_failed > 0 {
-          True -> exit(1)
-          False -> exit(0)
-        }
-      }
-      _ -> Nil
-    }
-    new_state
-  }
-
-  external fn run_tests(
-    fn(TestEvent, HandlerState) -> HandlerState,
-    HandlerState,
-    Option(List(String)),
-    List(String),
-    Capture,
-  ) -> Nil =
-    "./showtime_ffi.mjs" "run"
-
-  external fn start_arguments() -> List(String) =
-    "./showtime_ffi.mjs" "start_args"
-
-  external fn exit(Int) -> Nil =
-    "./showtime_ffi.mjs" "exit"
-
-  external fn system_time() -> Int =
-    "./showtime_ffi.mjs" "system_time"
+  test_event_handler(StartTestRun)
+  // Collect modules and notify the module handler to start the test-suites
+  let modules = collect_modules(test_module_handler, module_list)
+  test_event_handler(EndTestRun(
+    modules
+    |> list.length(),
+  ))
+  Nil
 }
 
-fn start_with_args(args, func) {
-  glint.new()
-  |> glint.add_command(
-    at: [],
-    do: mk_runner(func),
-    with: [
-      flag.strings(
-        called: "modules",
-        default: [],
-        explained: "Run only tests in the modules in this list",
-      ),
-      flag.strings(
-        called: "ignore",
-        default: [],
-        explained: "Ignore tests that are have tags matching a tag in this list",
-      ),
-      flag.string(
-        called: "capture",
-        default: "no",
-        explained: "Capture output: no (default) - output when tests are run, yes - output is captured and shown in report, mixed - output when run and in report",
-      ),
-    ],
-    described: "Runs test",
+// @target(erlang)
+// fn run(
+//   module_list: Option(List(String)),
+//   ignore_tags: List(String),
+//   capture: Capture,
+// ) {
+//   // Start event handler which will collect test-results and eventually
+//   // print test report
+//   let test_event_handler = event_handler.start()
+//   // Start module handler which receives msg about modules to test and
+//   // runs the test-suite for the module
+//   let test_module_handler =
+//     module_handler.start(
+//       test_event_handler,
+//       collect_test_functions,
+//       runner.run_test_suite,
+//       ignore_tags,
+//       capture,
+//     )
+
+//   test_event_handler(StartTestRun)
+//   // Collect modules and notify the module handler to start the test-suites
+//   let modules = collect_modules(test_module_handler, module_list)
+//   test_event_handler(EndTestRun(
+//     modules
+//     |> list.length(),
+//   ))
+//   Nil
+// }
+
+@target(javascript)
+import gleam/map
+@target(javascript)
+import gleam/option.{None, Option, Some}
+@target(javascript)
+import showtime/internal/common/test_suite.{TestEvent}
+@target(javascript)
+import showtime/internal/common/common_event_handler.{
+  Finished, HandlerState, NotStarted, handle_event,
+}
+@target(javascript)
+import showtime/internal/reports/formatter.{create_test_report}
+
+@target(javascript)
+pub fn main() {
+  use module_list, ignore_tags, capture <- start_with_args(start_arguments())
+  run_tests(
+    event_handler,
+    HandlerState(NotStarted, 0, map.new()),
+    module_list,
+    ignore_tags,
+    capture,
   )
+}
+
+// @target(javascript)
+// fn run(
+//   module_list: Option(List(String)),
+//   ignore_tags: List(String),
+//   capture: Capture,
+// ) {
+//   // Find test modules and run the tests using the event-handler for
+//   // collecting test-results and eventually print a test-report
+//   run_tests(
+//     event_handler,
+//     HandlerState(NotStarted, 0, map.new()),
+//     module_list,
+//     ignore_tags,
+//     capture,
+//   )
+// }
+
+@target(javascript)
+fn event_handler(event: TestEvent, state: HandlerState) {
+  let new_state = handle_event(event, system_time, state)
+  case new_state {
+    HandlerState(Finished(_), _, events) -> {
+      let #(report, num_failed) = create_test_report(events)
+      io.println(report)
+      case num_failed > 0 {
+        True -> exit(1)
+        False -> exit(0)
+      }
+    }
+    _ -> Nil
+  }
+  new_state
+}
+
+@target(javascript)
+@external(javascript, "./showtime_ffi.mjs", "run")
+fn run_tests(a: fn(TestEvent, HandlerState) -> HandlerState, b: HandlerState, c: Option(
+    List(String),
+  ), d: List(String), e: Capture) -> Nil
+
+@target(javascript)
+@external(javascript, "./showtime_ffi.mjs", "start_args")
+fn start_arguments() -> List(String)
+
+@target(javascript)
+@external(javascript, "./showtime_ffi.mjs", "exit")
+fn exit(a: Int) -> Nil
+
+@target(javascript)
+@external(javascript, "./showtime_ffi.mjs", "system_time")
+fn system_time() -> Int
+
+fn start_with_args(args, func) {
+  let modules_flag =
+    flag.new(flag.LS)
+    |> flag.default([])
+    |> flag.description("Run only tests in the modules in this list")
+
+  let ignore_flag =
+    flag.new(flag.LS)
+    |> flag.default([])
+    |> flag.description(
+      "Ignore tests that are have tags matching a tag in this list",
+    )
+
+  let capture_flag =
+    flag.new(flag.S)
+    |> flag.default("no")
+    |> flag.constraint(one_of(["yes", "no", "mixed"]))
+    |> flag.description(
+      "Capture output: no (default) - output when tests are run, yes - output is captured and shown in report, mixed - output when run and in report",
+    )
+
+  glint.new()
+  |> glint.add(
+    at: [],
+    do: glint.command(mk_runner(func, _))
+    |> glint.flag("modules", modules_flag)
+    |> glint.flag("ignore", ignore_flag)
+    |> glint.flag("capture", capture_flag)
+    |> glint.description("Runs test"),
+  )
+  |> glint.with_pretty_help(glint.default_pretty_help())
   |> glint.run(args)
 }
 
-fn mk_runner(func) {
-  fn(command: CommandInput) {
-    let module_list = case
-      command.flags
-      |> flag.get("modules")
-      |> result.unwrap(LS([]))
-    {
-      LS(module_list) ->
-        case module_list {
-          [] -> None
-          _ -> Some(module_list)
-        }
-      _ -> None
-    }
-    let ignore_tags = case
-      command.flags
-      |> flag.get("ignore")
-      |> result.unwrap(LS([]))
-    {
-      LS(ignore_tags) -> ignore_tags
-      _ -> []
-    }
-    let capture_output_result = case
-      command.flags
-      |> flag.get("capture")
-      |> result.map(fn(arg) {
-        let assert S(string_arg) = arg
-        S(string.lowercase(string_arg))
-      })
-      |> result.unwrap(S("no"))
-    {
-      S("no") -> Ok(No)
-      S("yes") -> Ok(Yes)
-      S("mixed") -> Ok(Mixed)
-      _ -> snag.error("Expected capture to be one of: ['yes', 'no', 'mixed']")
-    }
+fn mk_runner(func, command: CommandInput) {
+  let assert Ok(module_list) =
+    command.flags
+    |> flag.get_strings("modules")
+    |> result.map(fn(modules) {
+      case modules {
+        [] -> None
+        modules -> Some(modules)
+      }
+    })
+  let assert Ok(ignore_tags) =
+    command.flags
+    |> flag.get_strings("ignore")
 
-    case capture_output_result {
-      Ok(capture_output) -> func(module_list, ignore_tags, capture_output)
-      Error(error) ->
-        error
-        |> snag.pretty_print()
-        |> io.println()
-    }
-  }
-  // func(module_list, ignore_tags)
+  let assert Ok(capture_output) =
+    command.flags
+    |> flag.get_string("capture")
+    |> result.map(fn(arg) { string.lowercase(arg) })
+    |> result.map(fn(arg) {
+      case arg {
+        "no" -> No
+        "yes" -> Yes
+        "mixed" -> Mixed
+      }
+    })
+  func(module_list, ignore_tags, capture_output)
 }

--- a/src/showtime/internal/common/test_result.gleam
+++ b/src/showtime/internal/common/test_result.gleam
@@ -66,7 +66,7 @@ pub type ReasonDetail {
 // Gleam error detail is produced by showtime should and will hold all the information
 // about the assertion (both expected and got)
 pub type GleamErrorDetail {
-  Assert(
+  LetAssert(
     module: String,
     function: String,
     line_no: Int,

--- a/src/showtime/internal/erlang/discover.gleam
+++ b/src/showtime/internal/erlang/discover.gleam
@@ -1,160 +1,168 @@
-if erlang {
-  import gleam/io
-  import gleam/dynamic.{Dynamic}
-  import gleam/list
-  import gleam/string
-  import gleam/int
-  import gleam/option.{None, Option, Some}
-  import gleam/result
-  import gleam/erlang/file
-  import gleam/erlang/atom.{Atom}
-  import showtime/internal/common/test_suite.{
-    TestFunction, TestModule, TestModuleHandler, TestSuite,
-  }
-
-  // Module collector for erlang
-  // Will search the test folder for files ending with _test and notify
-  // the module handler about each module it finds
-  pub fn collect_modules(
-    test_module_handler: TestModuleHandler,
-    only_modules: Option(List(String)),
-  ) -> List(TestModule) {
-    collect_modules_in_folder("./test", test_module_handler, only_modules)
-  }
-
-  fn collect_modules_in_folder(
-    path: String,
-    test_module_handler: TestModuleHandler,
-    only_modules: Option(List(String)),
-  ) {
-    let module_prefix = get_module_prefix(path)
-    let assert Ok(files) = file.list_directory(path)
-    let test_modules_in_folder =
-      files
-      |> list.filter(string.ends_with(_, "_test.gleam"))
-      |> list.filter_map(fn(test_module_file) {
-        let module_name =
-          module_prefix <> {
-            test_module_file
-            |> string.replace(".gleam", "")
-          }
-        case only_modules {
-          Some(only_modules_list) -> {
-            let module_in_list =
-              only_modules_list
-              |> list.any(fn(only_module_name) {
-                only_module_name == module_name
-                |> string.replace("@", "/")
-              })
-            case module_in_list {
-              True -> {
-                let test_module =
-                  TestModule(module_name, Some(test_module_file))
-                test_module_handler(test_module)
-                Ok(test_module)
-              }
-
-              False -> Error(Nil)
-            }
-          }
-          None -> {
-            let test_module = TestModule(module_name, Some(test_module_file))
-            test_module_handler(test_module)
-            Ok(test_module)
-          }
-        }
-      })
-    let test_modules_in_subfolders =
-      files
-      |> list.map(fn(filename) { path <> "/" <> filename })
-      |> list.filter(fn(file) {
-        file.is_directory(file)
-        |> result.unwrap(False)
-      })
-      |> list.fold(
-        [],
-        fn(modules, subfolder) {
-          modules
-          |> list.append(collect_modules_in_folder(
-            subfolder,
-            test_module_handler,
-            only_modules,
-          ))
-        },
-      )
-    test_modules_in_folder
-    |> list.append(test_modules_in_subfolders)
-  }
-
-  fn get_module_prefix(path) {
-    let path_without_test =
-      path
-      |> string.replace("./test", "")
-
-    let path_without_leading_slash = case
-      string.starts_with(path_without_test, "/")
-    {
-      True -> string.drop_left(path_without_test, 1)
-      False -> path_without_test
-    }
-    let module_prefix =
-      path_without_leading_slash
-      |> string.replace("/", "@")
-    case string.length(module_prefix) {
-      0 -> module_prefix
-      _ -> module_prefix <> "@"
-    }
-  }
-
-  // Test function collector for erlang
-  // Uses erlang `apply` to run `module_info` for the test module
-  // and collects all the exports ending with _test into a `TestSuite`
-  pub fn collect_test_functions(module: TestModule) -> TestSuite {
-    let test_functions: List(#(Atom, Int)) =
-      apply(
-        atom.create_from_string(module.name),
-        atom.create_from_string("module_info"),
-        [dynamic.from(atom.create_from_string("exports"))],
-      )
-      |> dynamic.unsafe_coerce()
-
-    let test_functions_filtered =
-      test_functions
-      |> list.map(fn(entry) {
-        let assert #(name, arity) = entry
-        #(
-          name
-          |> atom.to_string(),
-          arity,
-        )
-      })
-      |> list.filter_map(fn(entry) {
-        let assert #(name, arity) = entry
-        case string.ends_with(name, "_test") {
-          True ->
-            case arity {
-              0 -> Ok(name)
-              _ -> {
-                io.println(
-                  "WARNING: function \"" <> name <> "\" has arity: " <> int.to_string(
-                    arity,
-                  ) <> " - cannot be used as test (needs to be 0)",
-                )
-                Error("Wrong arity")
-              }
-            }
-          False -> Error("Non matching name")
-        }
-      })
-      |> list.filter(string.ends_with(_, "_test"))
-      |> list.map(fn(function_name) { TestFunction(function_name) })
-    TestSuite(module, test_functions_filtered)
-  }
-
-  external fn apply(
-    module: Atom,
-    function: Atom,
-    args: List(Dynamic),
-  ) -> Dynamic =
-    "erlang" "apply"
+@target(erlang)
+import gleam/io
+@target(erlang)
+import gleam/dynamic.{Dynamic}
+@target(erlang)
+import gleam/list
+@target(erlang)
+import gleam/string
+@target(erlang)
+import gleam/int
+@target(erlang)
+import gleam/option.{None, Option, Some}
+@target(erlang)
+import gleam/result
+@target(erlang)
+import gleam/erlang/file
+@target(erlang)
+import gleam/erlang/atom.{Atom}
+@target(erlang)
+import showtime/internal/common/test_suite.{
+  TestFunction, TestModule, TestModuleHandler, TestSuite,
 }
+
+// Module collector for erlang
+// Will search the test folder for files ending with _test and notify
+// the module handler about each module it finds
+@target(erlang)
+pub fn collect_modules(
+  test_module_handler: TestModuleHandler,
+  only_modules: Option(List(String)),
+) -> List(TestModule) {
+  collect_modules_in_folder("./test", test_module_handler, only_modules)
+}
+
+@target(erlang)
+fn collect_modules_in_folder(
+  path: String,
+  test_module_handler: TestModuleHandler,
+  only_modules: Option(List(String)),
+) {
+  let module_prefix = get_module_prefix(path)
+  let assert Ok(files) = file.list_directory(path)
+  let test_modules_in_folder =
+    files
+    |> list.filter(string.ends_with(_, "_test.gleam"))
+    |> list.filter_map(fn(test_module_file) {
+      let module_name =
+        module_prefix <> {
+          test_module_file
+          |> string.replace(".gleam", "")
+        }
+      case only_modules {
+        Some(only_modules_list) -> {
+          let module_in_list =
+            only_modules_list
+            |> list.any(fn(only_module_name) {
+              only_module_name == module_name
+              |> string.replace("@", "/")
+            })
+          case module_in_list {
+            True -> {
+              let test_module = TestModule(module_name, Some(test_module_file))
+              test_module_handler(test_module)
+              Ok(test_module)
+            }
+
+            False -> Error(Nil)
+          }
+        }
+        None -> {
+          let test_module = TestModule(module_name, Some(test_module_file))
+          test_module_handler(test_module)
+          Ok(test_module)
+        }
+      }
+    })
+  let test_modules_in_subfolders =
+    files
+    |> list.map(fn(filename) { path <> "/" <> filename })
+    |> list.filter(fn(file) {
+      file.is_directory(file)
+      |> result.unwrap(False)
+    })
+    |> list.fold(
+      [],
+      fn(modules, subfolder) {
+        modules
+        |> list.append(collect_modules_in_folder(
+          subfolder,
+          test_module_handler,
+          only_modules,
+        ))
+      },
+    )
+  test_modules_in_folder
+  |> list.append(test_modules_in_subfolders)
+}
+
+@target(erlang)
+fn get_module_prefix(path) {
+  let path_without_test =
+    path
+    |> string.replace("./test", "")
+
+  let path_without_leading_slash = case
+    string.starts_with(path_without_test, "/")
+  {
+    True -> string.drop_left(path_without_test, 1)
+    False -> path_without_test
+  }
+  let module_prefix =
+    path_without_leading_slash
+    |> string.replace("/", "@")
+  case string.length(module_prefix) {
+    0 -> module_prefix
+    _ -> module_prefix <> "@"
+  }
+}
+
+// Test function collector for erlang
+// Uses erlang `apply` to run `module_info` for the test module
+// and collects all the exports ending with _test into a `TestSuite`
+@target(erlang)
+pub fn collect_test_functions(module: TestModule) -> TestSuite {
+  let test_functions: List(#(Atom, Int)) =
+    apply(
+      atom.create_from_string(module.name),
+      atom.create_from_string("module_info"),
+      [dynamic.from(atom.create_from_string("exports"))],
+    )
+    |> dynamic.unsafe_coerce()
+
+  let test_functions_filtered =
+    test_functions
+    |> list.map(fn(entry) {
+      let assert #(name, arity) = entry
+      #(
+        name
+        |> atom.to_string(),
+        arity,
+      )
+    })
+    |> list.filter_map(fn(entry) {
+      let assert #(name, arity) = entry
+      case string.ends_with(name, "_test") {
+        True ->
+          case arity {
+            0 -> Ok(name)
+            _ -> {
+              io.println(
+                "WARNING: function \"" <> name <> "\" has arity: " <> int.to_string(
+                  arity,
+                ) <> " - cannot be used as test (needs to be 0)",
+              )
+              Error("Wrong arity")
+            }
+          }
+        False -> Error("Non matching name")
+      }
+    })
+    |> list.filter(string.ends_with(_, "_test"))
+    |> list.map(fn(function_name) { TestFunction(function_name) })
+  TestSuite(module, test_functions_filtered)
+}
+
+@target(erlang)
+@external(erlang, "erlang", "apply")
+fn apply(module module: Atom, function function: Atom, args args: List(Dynamic)) -> Dynamic

--- a/src/showtime/internal/erlang/event_handler.gleam
+++ b/src/showtime/internal/erlang/event_handler.gleam
@@ -1,79 +1,89 @@
-if erlang {
-  import gleam/io
-  import gleam/otp/actor.{Continue, Stop}
-  import gleam/erlang/process.{Normal, Subject}
-  import gleam/map
-  import showtime/internal/common/test_suite.{EndTestRun, TestEvent}
-  import showtime/internal/common/common_event_handler.{
-    Finished, HandlerState, NotStarted, handle_event,
-  }
-  import showtime/internal/reports/formatter.{create_test_report}
-  import gleam/erlang.{Millisecond}
+@target(erlang)
+import gleam/io
+@target(erlang)
+import gleam/otp/actor.{Continue, Stop}
+@target(erlang)
+import gleam/erlang/process.{Normal, Subject}
+@target(erlang)
+import gleam/map
+@target(erlang)
+import showtime/internal/common/test_suite.{EndTestRun, TestEvent}
+@target(erlang)
+import showtime/internal/common/common_event_handler.{
+  Finished, HandlerState, NotStarted, handle_event,
+}
+@target(erlang)
+import showtime/internal/reports/formatter.{create_test_report}
+@target(erlang)
+import gleam/erlang.{Millisecond}
 
-  type EventHandlerMessage {
-    EventHandlerMessage(test_event: TestEvent, reply_to: Subject(Int))
-  }
+@target(erlang)
+type EventHandlerMessage {
+  EventHandlerMessage(test_event: TestEvent, reply_to: Subject(Int))
+}
 
-  // Starts an actor that receives test events and forwards the to the event handler
-  // When handler updates the state to `Finished` the actor will wait until handler
-  // reports that all modules are done and the stop
-  pub fn start() {
-    let assert Ok(subject) =
-      actor.start(
-        #(NotStarted, 0, map.new()),
-        fn(msg: EventHandlerMessage, state) {
-          let EventHandlerMessage(test_event, reply_to) = msg
-          let #(test_state, num_done, events) = state
-          let updated_state =
-            handle_event(
-              test_event,
-              system_time,
-              HandlerState(test_state, num_done, events),
-            )
-          case updated_state {
-            HandlerState(Finished(num_modules), num_done, events) if num_done == num_modules -> {
-              let #(test_report, num_failed) = create_test_report(events)
-              io.println(test_report)
-              process.send(reply_to, num_failed)
-              Stop(Normal)
-            }
-            HandlerState(test_state, num_done, events) ->
-              Continue(#(test_state, num_done, events))
+// Starts an actor that receives test events and forwards the to the event handler
+// When handler updates the state to `Finished` the actor will wait until handler
+// reports that all modules are done and the stop
+@target(erlang)
+pub fn start() {
+  let assert Ok(subject) =
+    actor.start(
+      #(NotStarted, 0, map.new()),
+      fn(msg: EventHandlerMessage, state) {
+        let EventHandlerMessage(test_event, reply_to) = msg
+        let #(test_state, num_done, events) = state
+        let updated_state =
+          handle_event(
+            test_event,
+            system_time,
+            HandlerState(test_state, num_done, events),
+          )
+        case updated_state {
+          HandlerState(Finished(num_modules), num_done, events) if num_done == num_modules -> {
+            let #(test_report, num_failed) = create_test_report(events)
+            io.println(test_report)
+            process.send(reply_to, num_failed)
+            Stop(Normal)
           }
-        },
-      )
-    let parent_subject = process.new_subject()
-
-    let selector =
-      process.new_selector()
-      |> process.selecting(parent_subject, fn(x) { x })
-
-    // Returns a callback that can receive test events
-    fn(test_event: TestEvent) {
-      case test_event {
-        EndTestRun(..) -> {
-          // When EndTestRun has been received the callback will wait until the
-          // actor has stopped
-          // TODO: Use a timeout?
-          process.send(subject, EventHandlerMessage(test_event, parent_subject))
-          let num_failed = process.select_forever(selector)
-          case num_failed > 0 {
-            True -> halt(1)
-            False -> halt(0)
-          }
+          HandlerState(test_state, num_done, events) ->
+            Continue(#(test_state, num_done, events))
         }
+      },
+    )
+  let parent_subject = process.new_subject()
 
-        // Normally just send the test event to the actor
-        _ ->
-          process.send(subject, EventHandlerMessage(test_event, parent_subject))
+  let selector =
+    process.new_selector()
+    |> process.selecting(parent_subject, fn(x) { x })
+
+  // Returns a callback that can receive test events
+  fn(test_event: TestEvent) {
+    case test_event {
+      EndTestRun(..) -> {
+        // When EndTestRun has been received the callback will wait until the
+        // actor has stopped
+        // TODO: Use a timeout?
+        process.send(subject, EventHandlerMessage(test_event, parent_subject))
+        let num_failed = process.select_forever(selector)
+        case num_failed > 0 {
+          True -> halt(1)
+          False -> halt(0)
+        }
       }
+
+      // Normally just send the test event to the actor
+      _ ->
+        process.send(subject, EventHandlerMessage(test_event, parent_subject))
     }
   }
+}
 
-  external fn halt(Int) -> Nil =
-    "erlang" "halt"
+@target(erlang)
+@external(erlang, "erlang", "halt")
+fn halt(a: Int) -> Nil
 
-  fn system_time() {
-    erlang.system_time(Millisecond)
-  }
+@target(erlang)
+fn system_time() {
+  erlang.system_time(Millisecond)
 }

--- a/src/showtime/internal/erlang/module_handler.gleam
+++ b/src/showtime/internal/erlang/module_handler.gleam
@@ -1,43 +1,41 @@
-if erlang {
-  import gleam/otp/actor.{Continue}
-  import gleam/erlang/process
-  import showtime/internal/common/test_suite.{
-    EndTestSuite, StartTestSuite, TestEventHandler, TestFunctionCollector,
-    TestModule, TestRunner,
-  }
-  import showtime/internal/common/cli.{Capture}
+@target(erlang)
+import gleam/otp/actor.{Continue}
+@target(erlang)
+import gleam/erlang/process
+@target(erlang)
+import showtime/internal/common/test_suite.{
+  EndTestSuite, StartTestSuite, TestEventHandler, TestFunctionCollector,
+  TestModule, TestRunner,
+}
+@target(erlang)
+import showtime/internal/common/cli.{Capture}
 
-  pub fn start(
-    test_event_handler: TestEventHandler,
-    test_function_collector: TestFunctionCollector,
-    run_test_suite: TestRunner,
-    ignore_tags: List(String),
-    capture: Capture,
-  ) {
-    let assert Ok(subject) =
-      actor.start(
-        Nil,
-        fn(module: TestModule, state) {
-          process.start(
-            fn() {
-              let test_suite = test_function_collector(module)
-              test_event_handler(StartTestSuite(module))
-              run_test_suite(
-                test_suite,
-                test_event_handler,
-                ignore_tags,
-                capture,
-              )
-              test_event_handler(EndTestSuite(module))
-            },
-            False,
-          )
-          Continue(state)
-        },
-      )
-    fn(test_module: TestModule) {
-      process.send(subject, test_module)
-      Nil
-    }
+@target(erlang)
+pub fn start(
+  test_event_handler: TestEventHandler,
+  test_function_collector: TestFunctionCollector,
+  run_test_suite: TestRunner,
+  ignore_tags: List(String),
+  capture: Capture,
+) {
+  let assert Ok(subject) =
+    actor.start(
+      Nil,
+      fn(module: TestModule, state) {
+        process.start(
+          fn() {
+            let test_suite = test_function_collector(module)
+            test_event_handler(StartTestSuite(module))
+            run_test_suite(test_suite, test_event_handler, ignore_tags, capture)
+            test_event_handler(EndTestSuite(module))
+          },
+          False,
+        )
+        Continue(state)
+      },
+    )
+  fn(test_module: TestModule) {
+    process.send(subject, test_module)
+    Nil
   }
 }

--- a/src/showtime/internal/erlang/runner.gleam
+++ b/src/showtime/internal/erlang/runner.gleam
@@ -1,53 +1,56 @@
-if erlang {
-  import gleam/list
-  import gleam/erlang/atom.{Atom}
-  import showtime/internal/common/test_suite.{
-    EndTest, StartTest, TestEventHandler, TestSuite,
-  }
-  import showtime/internal/common/test_result.{TestResult}
-  import showtime/internal/common/cli.{Capture}
-
-  // Runs all tests in a test suite
-  pub fn run_test_suite(
-    test_suite: TestSuite,
-    test_event_handler: TestEventHandler,
-    ignore_tags: List(String),
-    capture: Capture,
-  ) {
-    test_suite.tests
-    |> list.each(fn(test) {
-      test_event_handler(StartTest(test_suite.module, test))
-      let result =
-        run_test(test_suite.module.name, test.name, ignore_tags, capture)
-      test_event_handler(EndTest(test_suite.module, test, result))
-    })
-  }
-
-  // Wrapper around the ffi function that converts names to atoms
-  pub fn run_test(
-    module_name: String,
-    test_name: String,
-    ignore_tags: List(String),
-    capture: Capture,
-  ) -> TestResult {
-    let result =
-      run_test_ffi(
-        atom.create_from_string(module_name),
-        atom.create_from_string(test_name),
-        ignore_tags,
-        capture,
-      )
-    result
-  }
-
-  // Calls ffi for running a test function
-  // The ffi will take care of mapping the result and exception to the data-types
-  // used in gleam
-  external fn run_test_ffi(
-    module: Atom,
-    function: Atom,
-    ignore_tags: List(String),
-    capture: Capture,
-  ) -> TestResult =
-    "showtime_ffi" "run_test"
+@target(erlang)
+import gleam/list
+@target(erlang)
+import gleam/erlang/atom.{Atom}
+@target(erlang)
+import showtime/internal/common/test_suite.{
+  EndTest, StartTest, TestEventHandler, TestSuite,
 }
+@target(erlang)
+import showtime/internal/common/test_result.{TestResult}
+@target(erlang)
+import showtime/internal/common/cli.{Capture}
+
+// Runs all tests in a test suite
+@target(erlang)
+pub fn run_test_suite(
+  test_suite: TestSuite,
+  test_event_handler: TestEventHandler,
+  ignore_tags: List(String),
+  capture: Capture,
+) {
+  test_suite.tests
+  |> list.each(fn(test) {
+    test_event_handler(StartTest(test_suite.module, test))
+    let result =
+      run_test(test_suite.module.name, test.name, ignore_tags, capture)
+    test_event_handler(EndTest(test_suite.module, test, result))
+  })
+}
+
+// Wrapper around the ffi function that converts names to atoms
+@target(erlang)
+pub fn run_test(
+  module_name: String,
+  test_name: String,
+  ignore_tags: List(String),
+  capture: Capture,
+) -> TestResult {
+  let result =
+    run_test_ffi(
+      atom.create_from_string(module_name),
+      atom.create_from_string(test_name),
+      ignore_tags,
+      capture,
+    )
+  result
+}
+
+// Calls ffi for running a test function
+// The ffi will take care of mapping the result and exception to the data-types
+// used in gleam
+@target(erlang)
+@external(erlang, "showtime_ffi", "run_test")
+fn run_test_ffi(module module: Atom, function function: Atom, ignore_tags ignore_tags: List(
+    String,
+  ), capture capture: Capture) -> TestResult

--- a/src/showtime/internal/reports/formatter.gleam
+++ b/src/showtime/internal/reports/formatter.gleam
@@ -6,9 +6,9 @@ import gleam/option.{None, Option, Some}
 import gleam/map.{Map}
 import gleam/dynamic.{Dynamic}
 import showtime/internal/common/test_result.{
-  Assert, AssertEqual, AssertMatch, AssertNotEqual, Expected, Expression,
-  GenericException, GleamAssert, GleamError, GleamErrorDetail, Ignored, Pattern,
-  ReasonDetail, Trace, TraceModule, Value,
+  AssertEqual, AssertMatch, AssertNotEqual, Expected, Expression,
+  GenericException, GleamAssert, GleamError, GleamErrorDetail, Ignored,
+  LetAssert, Pattern, ReasonDetail, Trace, TraceModule, Value,
 }
 import showtime/internal/common/test_suite.{CompletedTestRun, TestRun}
 import showtime/tests/should.{Assertion, Eq, Fail, IsError, IsOk, NotEq}
@@ -287,7 +287,7 @@ fn gleam_error_to_unified(
   stacktrace: List(Trace),
 ) -> UnifiedError {
   case gleam_error {
-    Assert(_module, _function, _line_no, _message, value) -> {
+    LetAssert(_module, _function, _line_no, _message, value) -> {
       let result: Result(Dynamic, Assertion(Dynamic, Dynamic)) =
         dynamic.unsafe_coerce(value)
       let assert Error(assertion) = result

--- a/src/showtime_ffi.mjs
+++ b/src/showtime_ffi.mjs
@@ -9,7 +9,7 @@ import {
   EndTestSuite,
 } from "./showtime/internal/common/test_suite.mjs";
 import {
-  Assert,
+  LetAssert,
   ErlangException,
   GenericException,
   GleamAssert,
@@ -129,7 +129,7 @@ export const run = async (
                 new ErlangException(
                   new ErlangError(),
                   new GleamError(
-                    new Assert(
+                    new LetAssert(
                       test_module.name,
                       fnName,
                       // TODO: Fix line number
@@ -180,7 +180,7 @@ export const run = async (
                 new ErlangException(
                   new ErlangError(),
                   new GleamError(
-                    new Assert(
+                    new LetAssert(
                       test_module.name,
                       fnName,
                       error.line ? error.line : 0,

--- a/test/showtime_test.gleam
+++ b/test/showtime_test.gleam
@@ -376,24 +376,22 @@ pub fn table_test() {
   )
 }
 
-if javascript {
-  import gleam/dynamic.{Dynamic}
+@target(javascript)
+import gleam/dynamic.{Dynamic}
 
-  pub fn generic_exception_test() {
-    throw_exception(dynamic.from(TestType("Generic", [])))
-  }
-
-  external fn throw_exception(exception: Dynamic) -> Nil =
-    "./test_ffi.mjs" "throwException"
+@target(javascript)
+pub fn generic_exception_test() {
+  throw_exception(dynamic.from(TestType("Generic", [])))
 }
 
-if erlang {
-  import gleam/dynamic.{Dynamic}
+@external(erlang, "test_ffi", "throw_exception")
+@external(javascript, "./test_ffi.mjs", "throwException")
+fn throw_exception(exception exception: Dynamic) -> Nil
 
-  pub fn generic_exception_test() {
-    throw_exception(dynamic.from(TestType("Generic", [])))
-  }
+@target(erlang)
+import gleam/dynamic.{Dynamic}
 
-  external fn throw_exception(exception: Dynamic) -> Nil =
-    "test_ffi" "throw_exception"
+@target(erlang)
+pub fn generic_exception_test() {
+  throw_exception(dynamic.from(TestType("Generic", [])))
 }

--- a/test/showtime_test.gleam
+++ b/test/showtime_test.gleam
@@ -1,7 +1,6 @@
 import gleam/io
 import gleam/option.{None}
 import gleam/list
-import gleeunit
 import gleeunit/should as gshould
 import showtime
 import showtime/tests/should
@@ -19,7 +18,6 @@ pub type TestType {
 
 pub fn main() {
   showtime.main()
-  // gleeunit.main()
 }
 
 pub fn i_am_test() {


### PR DESCRIPTION
- Updated for gleam 0.30
- Using `glint` 0.12-rc5 (which supports gleam 0.30)
- Using `gap` 0.7.0 for increased diff performance